### PR TITLE
Admin page players

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -41,7 +41,7 @@
                     <div class="panel panel-danger">
                         <div class="panel-heading panel-heading-custom">{{item.date}}</div>
                         <div class="panel-body">
-                            <p class="panel-news-body">{{item.content}}</p>
+                            <p class="panel-news-body" [innerHTML]="parseNewLine(item.content)"></p>
                             <p class="news-sig">{{item.author}}</p>
                         </div>
                     </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -61,6 +61,15 @@ export class HomeComponent implements AfterViewInit {
         });
     }
 
+    public parseNewLine(content: string) {
+        const newLine = /\n/gi;
+        if (content) {
+            return content.replace(newLine, '<br>');
+        } else {
+            return content;
+        }
+    }
+
     ngAfterViewInit() {
         // SHOW-HIDE NEWS SECTION
 

--- a/src/app/services/database/news-databse.service.ts
+++ b/src/app/services/database/news-databse.service.ts
@@ -153,6 +153,17 @@ export class NewsDatabaseService {
             firstThree[1] = news[1];
             firstThree[2] = news[2];
 
+            const newLine = /\n/gi;
+            firstThree.forEach(newsItem => {
+                if (newsItem.content) {
+                    newsItem.content.replace(newLine, 'LINEBREAK');
+                }
+            });
+            // firstThree.forEach(newsItem => {
+            //     const newLine = /\n/gi;
+            //     newsItem.content.replace(newLine, '<br>');
+            // });
+
             // then return that array. now the result should be the three most recent news items
             return firstThree;
         });

--- a/src/app/sub-pages/admin/news-management/news-management.component.html
+++ b/src/app/sub-pages/admin/news-management/news-management.component.html
@@ -11,7 +11,7 @@
         <div class="row" *ngFor="let item of newsListWithId">
             <div class="col-sm-3">{{ item.date }}</div>
             <div class="col-sm-2">{{ item.author }}</div>
-            <div class="col-sm-5">{{ item.content }}</div>
+            <div class="col-sm-5" [innerHTML]="item.content"></div>
             <div class="col-sm-1">
                 <button class="btn btn-success" (click)="editNewsItem(item.id)">Change</button>
             </div>

--- a/src/app/sub-pages/admin/news-management/news-management.component.html
+++ b/src/app/sub-pages/admin/news-management/news-management.component.html
@@ -76,7 +76,7 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="flex-container justify-center">
-                        <input type="submit" [disabled]="newsForm.valid" class="btn btn-info">
+                        <input type="submit" [disabled]="newsForm.invalid" class="btn btn-info">
                     </div>
                 </div>
             </div>

--- a/src/app/sub-pages/admin/news-management/news-management.component.ts
+++ b/src/app/sub-pages/admin/news-management/news-management.component.ts
@@ -44,7 +44,16 @@ export class NewsManagementComponent implements OnInit {
         const lol = this._newsData.getNews()
         .map(data => {
             data.sort(function(a, b) { return b.dateUnix - a.dateUnix; } );
-            return data;
+            return data.map(newsItem => {
+                const newLine = /\n/gi;
+                const iteratedNewsItem = {
+                    author: newsItem.author,
+                    date: newsItem.date,
+                    content: newsItem.content.replace(newLine, '<br/>'),
+                    id: newsItem.id
+                };
+                return iteratedNewsItem;
+            });
         })
         .subscribe(result => {
             // console.log('rr result', result);
@@ -54,10 +63,11 @@ export class NewsManagementComponent implements OnInit {
         // map observable from the service and then subscribe to it via the newslist array
         this._newsData.newsObservable.map(newslist => {
             return newslist.map(newsItem => {
+
                 const myNewsItem: NewsItem = {
                     author: newsItem.author,
                     date: newsItem.date,
-                    content: newsItem.content
+                    content: newsItem.content.replace('\n', 'LINEBREAK')
                 };
                 return myNewsItem;
             });


### PR DESCRIPTION
Rolled out some fixes for bugs I found while attempting to make a news post:

The submit button on the admin/addnews was incorrectly disabling when it shouldn't. 
Line breaks entered on the form now properly display on both the and in summary and the front page. Used .replace on /\n\/gi to <br> and then used [innerHTML] to display the result. Page does seem noticeably slower, so I'm not going to apply that to older news just yet.