### PR TITLE
Challenges

### DIFF
--- a/src/app/services/database/ladder-database.service.ts
+++ b/src/app/services/database/ladder-database.service.ts
@@ -132,6 +132,27 @@ export class LadderDatabaseService {
         dbRef.update(id, {google: googleInc});
     }
 
+    public challengerWinPost() {}
+
+    // method to update player adjustments from a defender win
+    public defenderWinPost(chall, def, result) {
+        // create a database reference
+        const dbRef = this._database.list('/ladder/' + result.game + '/players');
+
+        // update defender stats. only wins and elo should be adjusted
+        dbRef.update(def.id, {
+            wins: def.wins,
+            elo: def.elo
+        });
+
+        // update challenger. losses, elo, and recent player should be adjusted
+        dbRef.update(chall.id, {
+            losses: chall.losses,
+            elo: chall.elo,
+            recentOpponent: chall.recentOpponent
+        });
+    }
+
     // public instantiation() {
     //     this._tempPlayers.forEach(element => {
     //         this.addPlayer('tekken', element);

--- a/src/app/services/database/ladder-database.service.ts
+++ b/src/app/services/database/ladder-database.service.ts
@@ -132,7 +132,29 @@ export class LadderDatabaseService {
         dbRef.update(id, {google: googleInc});
     }
 
-    public challengerWinPost() {}
+    // method to update player adjustmentgs from a challenger win
+    public challengerWinPost(challArr: any[], def, result) {
+        // create a database reference for the game in question
+        const dbRef = this._database.list('/ladder/' + result.game + '/players');
+
+        // update defender stats. losses, rank, elo
+        dbRef.update(def.id, {
+            losses: def.losses,
+            elo: def.elo,
+            rank: def.rank
+        });
+
+        // update everyone in the list of affected players array
+        // rank, wins, elo. because we carried over the entire player from the db,
+        // reuploadaing the win and elo count from players not actually in the match shouldnt change anything
+        challArr.forEach(chall => {
+            dbRef.update(chall.id, {
+                wins: chall.wins,
+                elo: chall.elo,
+                rank: chall.rank
+            });
+        });
+    }
 
     // method to update player adjustments from a defender win
     public defenderWinPost(chall, def, result) {

--- a/src/app/services/database/pending-database.service.ts
+++ b/src/app/services/database/pending-database.service.ts
@@ -74,15 +74,18 @@ export class PendingDatabaseService {
         this._database.list('/w-pending/join').remove(id);
     }
 
+    // method to add a pending link request
     public addPendingLink(link) {
         this._database.list('/w-pending/link').push(link);
     }
 
+    // method to delete a pending link request
     public deletePendingLink(id) {
         console.log('removing link request with id', id);
         this._database.list('/w-pending/link').remove(id);
     }
 
+    // method to make sure a duplicate link request isnt being sent. returns t/f
     public dupeLinkCheck(game: string, id: string) {
 
         let dupeCheck = false; // reset to false each call
@@ -99,6 +102,8 @@ export class PendingDatabaseService {
         return dupeCheck;
     }
 
+    // method to get a list of all pending challenges from the DB. uses snapshotChanges to grab keys.
+    // this also alleviates the need for a numerical index when storing records, which also solves a lot of bugs
     public getListOfPendingChallenges() {
         return this._database.list('/w-pending/new-challenge').valueChanges().map(pendingList => {
             const listOfKeys = [];
@@ -112,22 +117,27 @@ export class PendingDatabaseService {
         });
     }
 
+    // method to add an anonymouse challenge for approval
     public addPendingChallenge(challenge) {
         this._database.list('/w-pending/new-challenge').push(challenge);
     }
 
+    // method to delete an anonymouse challenge from DB
     public deletePendingChallenge(id) {
         this._database.list('/w-pending/new-challenge').remove(id);
     }
 
+    // method to add a challenge result for approval
     public addResult(result) {
         this._database.list('/w-pending/result').push(result);
     }
 
+    // method to delete a challenge result for approval
     public deleteResult(id: string) {
         this._database.list('w-pending/result').remove(id);
     }
 
+    // method to get a list of all pending result postings
     public getListOfResults() {
         return this._database.list('/w-pending/result').valueChanges().map(pendingList => {
             const listOfKeys = [];
@@ -141,6 +151,7 @@ export class PendingDatabaseService {
         });
     }
 
+    // method to make sure a duplicate result isnt being posted for the same challenge
     public dupeResultCheck(id: string) {
         let dupeCheck = false; // reset to false each call
         // go through each item of the list and see if the psn id's and game both match

--- a/src/app/services/database/pending-database.service.ts
+++ b/src/app/services/database/pending-database.service.ts
@@ -13,6 +13,7 @@ export class PendingDatabaseService {
     private _listOfPending;
     private _MAXPENDING = 30; // maximum number of pending entries
     private _listOfPendingLinks;
+    private _listOfResults;
 
     // instantiate list of pending applications
     constructor( private _database: AngularFireDatabase ) {
@@ -22,6 +23,10 @@ export class PendingDatabaseService {
 
         this._database.list('/w-pending/link').valueChanges().subscribe(listOfLinks => {
             this._listOfPendingLinks = listOfLinks;
+        });
+
+        this._database.list('/w-pending/result').valueChanges().subscribe(resultList => {
+            this._listOfResults = resultList;
         });
     }
 
@@ -134,5 +139,18 @@ export class PendingDatabaseService {
             });
             return pendingList;
         });
+    }
+
+    public dupeResultCheck(id: string) {
+        let dupeCheck = false; // reset to false each call
+        // go through each item of the list and see if the psn id's and game both match
+        // if so, set the flag to true
+        this._listOfResults.forEach(result => {
+            console.log(`Checking incoming ${id} vs iteration ${result.challengeDBId}`);
+            if (result.challengeDBId === id) {
+                dupeCheck = true;
+            }
+        });
+        return dupeCheck;
     }
 }

--- a/src/app/services/database/pending-database.service.ts
+++ b/src/app/services/database/pending-database.service.ts
@@ -114,4 +114,25 @@ export class PendingDatabaseService {
     public deletePendingChallenge(id) {
         this._database.list('/w-pending/new-challenge').remove(id);
     }
+
+    public addResult(result) {
+        this._database.list('/w-pending/result').push(result);
+    }
+
+    public deleteResult(id: string) {
+        this._database.list('w-pending/result').remove(id);
+    }
+
+    public getListOfResults() {
+        return this._database.list('/w-pending/result').valueChanges().map(pendingList => {
+            const listOfKeys = [];
+            this._database.list('/w-pending/result').snapshotChanges().subscribe(snapshotList => {
+                snapshotList.forEach(function(snapshot) {
+                    listOfKeys.push(snapshot.key);
+                });
+                pendingList.forEach(function(pendingItem, index) {pendingList[index]['id'] = listOfKeys[index]; });
+            });
+            return pendingList;
+        });
+    }
 }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.css
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.css
@@ -25,3 +25,10 @@
     align-items: center;
     justify-content: space-around;
 }
+
+.challenge-pending-result-side-row {
+    min-height: 86px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -46,6 +46,32 @@
             </div>
             <div class="col-sm-1 challenge-pending-min-height challenge-pending-item-buttons">
                 <button class="btn btn-danger" (click)="deleteActiveChallenge(challenge.id)">Delete</button>
+            </div>
         </div> <!-- end looped active challenge row -->
+        <div class="row"> <!-- begin result title row -->
+            <div class="col-sm-12">
+                <h3 class="text-center font-bangers">List of results needing approval</h3>
+            </div>
+        </div> <!-- end result title row -->
+        <div class="row text-center"> <!-- behin result header row -->
+            <div class="col-sm-2">
+                <p class="font-banger">Game</p>
+            </div>
+            <div class="col-sm-8">Challenge</div>
+            <div class="col-sm-2"></div>
+        </div> <!-- end result header row -->
+        <div class="row" *ngFor="let result of listOfResults">
+            <div class="col-sm-2 challenge-pending-result-side-row">{{ result.game }}</div>
+            <div class="col-sm-8">
+                <h3 class="text-center">({{result.challengerRank}}) {{result.challengerName}} <strong>{{result.challengerScore}} - {{result.defenderScore}}</strong> {{result.defenderName}} ({{result.defenderRank}})</h3>
+                <p class="text-center">Deadline: {{ unixConvert(result.deadline) }}</p>
+            </div>
+            <div class="col-sm-2 challenge-pending-result-side-row">
+                <div class="flex-container justify-around">
+                    <button class="btn btn-success">Approve</button>
+                    <button class="btn btn-danger">Deny</button>
+                </div>
+            </div>
+        </div>
     </div> <!-- end container -->
 </div>

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -68,7 +68,7 @@
             </div>
             <div class="col-sm-2 challenge-pending-result-side-row">
                 <div class="flex-container justify-around">
-                    <button class="btn btn-success">Approve</button>
+                    <button class="btn btn-success" (click)="approveResult(result)">Approve</button>
                     <button class="btn btn-danger" (click)="deleteResult(result.id)">Deny</button>
                 </div>
             </div>

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -69,7 +69,7 @@
             <div class="col-sm-2 challenge-pending-result-side-row">
                 <div class="flex-container justify-around">
                     <button class="btn btn-success">Approve</button>
-                    <button class="btn btn-danger">Deny</button>
+                    <button class="btn btn-danger" (click)="deleteResult(result.id)">Deny</button>
                 </div>
             </div>
         </div>

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -119,8 +119,10 @@ export class ChallengeManagementComponent {
 
         // make sure defender isnt included in both affectedPlayers and currentDefender
         // if current defender is actually in the afectedPlayers list, he should always be first so a simple shift() should work
+        // we should also adjust the defenders rank if thats the case
         if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
             this.listOfAffectedPlayers.shift();
+            this._currentDefender.rank++;
         }
 
         console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -122,7 +122,6 @@ export class ChallengeManagementComponent {
         // we should also adjust the defenders rank if thats the case
         if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
             this.listOfAffectedPlayers.shift();
-            this._currentDefender.rank++;
         }
 
         console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);
@@ -131,7 +130,10 @@ export class ChallengeManagementComponent {
             // update affected players
         });
 
-        // update defender
+        // update defender and delete challenge and result from database
+        this._ladderDB.challengerWinPost(this.listOfAffectedPlayers, this._currentDefender, result);
+        this._challengeDB.deleteChallenge(result.challengeDBId);
+        this._pending.deleteResult(result.id);
 }
 
     // method to make player adjustments based off a defender win

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -86,10 +86,10 @@ export class ChallengeManagementComponent {
             const lastIndex = this.listOfAffectedPlayers.length - 1;
             this.listOfAffectedPlayers[lastIndex].recentOpponent = result.defenderId;
             if (result.challengerScore > result.defenderScore) {
-                this._winAdjust(result);
+                this._winAdjust(result, lastIndex);
             }
             if (result.challengerScore < result.defenderScore) {
-                this._lossAdjust(result);
+                this._lossAdjust(result, lastIndex);
             }
             if (result.challengerScore === result.defenderScore) {
                 console.log('ERROR: I dont know what to do with a tie :(');
@@ -98,9 +98,7 @@ export class ChallengeManagementComponent {
     }
 
     // method to make player adjustments based off a challenger win
-    private _winAdjust(result) {
-        // the last player in the list of affected players should always be the challenger.
-        const chall = this.listOfAffectedPlayers.length() - 1;
+    private _winAdjust(result, chall) {
 
         // increment all affected players rank by 1
         this.listOfAffectedPlayers.forEach(player => { player.rank++; });
@@ -123,6 +121,7 @@ export class ChallengeManagementComponent {
             this.listOfAffectedPlayers.shift();
         }
 
+        console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);
         // finally, push adjustments to db
         this.listOfAffectedPlayers.forEach(player => {
             // update affected players
@@ -132,15 +131,14 @@ export class ChallengeManagementComponent {
 }
 
     // method to make player adjustments based off a defender win
-    private _lossAdjust(result) {
+    private _lossAdjust(result, chall) {
         // the last player in the list of affected players should always be the challenger.
         // in the event of a defender win, that's all we're interested in since no ranks will be moved
-        const chall = this.listOfAffectedPlayers.length() - 1;
+        // const chall = this.listOfAffectedPlayers.length() - 1;
 
         // add wins and losses
         this._currentDefender.wins++;
         this.listOfAffectedPlayers[chall].losses++;
-
         // adjust elo
         const challELO = this.listOfAffectedPlayers[chall].elo;
         const defELO = this._currentDefender.elo;
@@ -153,6 +151,7 @@ export class ChallengeManagementComponent {
             this.listOfAffectedPlayers.champWait = Date.now() + 259200000;
         }
 
+        console.log('post defender win adjustments', this._currentDefender, this.listOfAffectedPlayers[chall]);
         // update defender
 
         // update challenger

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -69,8 +69,11 @@ export class ChallengeManagementComponent {
     }
 
     public approveResult(result) {
-        this.listOfAffectedPlayers = [];
-        this._currentDefender = null;
+        this.listOfAffectedPlayers = []; // list of all players whos rank will be lowered
+        this._currentDefender = null; // the current defender.
+        // NOTE: The reason the current defender is seperate is because its possible that the defender has a higher than 3 rank difference
+        // if they won their own challenge. as a result, any adjustments to rank to the defender only will be done in this object.
+        // when it comes time to update, we will make sure that the same person does not get pushed twice
         this._ladderDB.getPlayers(result.game).subscribe(playerList => {
             this._currentDefender = playerList.find(function(e, i, a) {
                 if (e.id === result.defenderId) { return true; }
@@ -96,11 +99,78 @@ export class ChallengeManagementComponent {
 
     // method to make player adjustments based off a challenger win
     private _winAdjust(result) {
-        const lastIndex = this.listOfAffectedPlayers.length();
-    }
+        // the last player in the list of affected players should always be the challenger.
+        const chall = this.listOfAffectedPlayers.length() - 1;
+
+        // increment all affected players rank by 1
+        this.listOfAffectedPlayers.forEach(player => { player.rank++; });
+        // then readjust challengers rank based on the challenge data
+        this.listOfAffectedPlayers[chall].rank = result.defenderRank;
+
+        // adjust wins and losses
+        this._currentDefender.losses++;
+        this.listOfAffectedPlayers[chall].wins++;
+
+        // adjust ELO
+        const challELO = this.listOfAffectedPlayers[chall].elo;
+        const defELO = this._currentDefender.elo;
+        this.listOfAffectedPlayers[chall].elo = this._getNewRating(challELO, defELO, 1);
+        this._currentDefender.elo = this._getNewRating(defELO, challELO, 0);
+
+        // make sure defender isnt included in both affectedPlayers and currentDefender
+        // if current defender is actually in the afectedPlayers list, he should always be first so a simple shift() should work
+        if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
+            this.listOfAffectedPlayers.shift();
+        }
+
+        // finally, push adjustments to db
+        this.listOfAffectedPlayers.forEach(player => {
+            // update affected players
+        });
+
+        // update defender
+}
 
     // method to make player adjustments based off a defender win
-    private _lossAdjust(result) {}
+    private _lossAdjust(result) {
+        // the last player in the list of affected players should always be the challenger.
+        // in the event of a defender win, that's all we're interested in since no ranks will be moved
+        const chall = this.listOfAffectedPlayers.length() - 1;
+
+        // add wins and losses
+        this._currentDefender.wins++;
+        this.listOfAffectedPlayers[chall].losses++;
+
+        // adjust elo
+        const challELO = this.listOfAffectedPlayers[chall].elo;
+        const defELO = this._currentDefender.elo;
+        this.listOfAffectedPlayers[chall].elo = this._getNewRating(challELO, defELO, 0);
+        this._currentDefender.elo = this._getNewRating(defELO, challELO, 1);
+
+        // if the challenger rank is #2, force them to wait a couple days to place another challenge so that they can't
+        // constantly have a lock on the title shot. we'll give them 3 days, 259200000 seconds
+        if (this.listOfAffectedPlayers[chall].rank === 2) {
+            this.listOfAffectedPlayers.champWait = Date.now() + 259200000;
+        }
+
+        // update defender
+
+        // update challenger
+    }
+
+    // ELO functions from github: moroshko
+    private _getRatingDelta(myRating, opponentRating, myGameResult) {
+        if ([0, 0.5, 1].indexOf(myGameResult) === -1) {
+          return null;
+        }
+
+        const myChanceToWin = 1 / ( 1 + Math.pow(10, (opponentRating - myRating) / 400));
+
+        return Math.round(32 * (myGameResult - myChanceToWin));
+    }
+    private _getNewRating(myRating, opponentRating, myGameResult) {
+        return myRating + this._getRatingDelta(myRating, opponentRating, myGameResult);
+    }
 
     public unixConvert(unix: number): Date {
         return new Date(unix);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -57,6 +57,13 @@ export class ChallengeManagementComponent {
         }
     }
 
+    // method to delete a result
+    public deleteResult(id) {
+        if (confirm('Are you sure you want to delete this result?')) {
+            this._pending.deleteResult(id);
+        }
+    }
+
     public unixConvert(unix: number): Date {
         return new Date(unix);
     }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -11,30 +11,33 @@ import { ChallengeDatabaseService } from './../../../services/database/challenge
 
 export class ChallengeManagementComponent {
 
-    public listOfPendingChallenges;
-    public listOfActiveChallenges;
+    public listOfPendingChallenges; // will contain a list of anon chasllenges that are pending
+    public listOfActiveChallenges; // will conatin a list of active challenges
 
     constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService) {
         this._pending.getListOfPendingChallenges().subscribe(pendingList => {
             this.listOfPendingChallenges = pendingList;
-            console.log('list of pendings:', this.listOfPendingChallenges);
+            // onsole.log('list of pendings:', this.listOfPendingChallenges);
         });
 
         this._challengeDB.getListOfChallenges().subscribe(challengeList => {
             this.listOfActiveChallenges = challengeList;
-            console.log('list of actives:', this.listOfActiveChallenges);
+            // console.log('list of actives:', this.listOfActiveChallenges);
         });
     }
 
+    // method to deny challenge. deletes it from the pending list
     public denyChallenge(id) {
         this._pending.deletePendingChallenge(id);
     }
 
+    // method to approve challenge. deletes it from the pending list and adds to active challenges
     public approveChallenge(challenge, id) {
         if (confirm('Confirm adding selected challenge to official challenge list')) {
+            // add 10 days in ubnix time to the current date to pass correct deadling
             challenge['deadline'] = Date.now() + 864000000;
             this._pending.deletePendingChallenge(id);
-            challenge.id = null;
+            challenge.id = null; // remove the challenge id from the pending list so that its not confused with the id in the challenge list
             console.log('submitting challenge:', challenge);
             this._challengeDB.addChallenge(challenge);
 
@@ -42,6 +45,7 @@ export class ChallengeManagementComponent {
 
     }
 
+    // method to delete an active challenge from the database
     public deleteActiveChallenge(id) {
         if (confirm('Are you sure you want to delete this challenge?')) {
             this._challengeDB.deleteChallenge(id);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -13,6 +13,7 @@ export class ChallengeManagementComponent {
 
     public listOfPendingChallenges; // will contain a list of anon chasllenges that are pending
     public listOfActiveChallenges; // will conatin a list of active challenges
+    public listOfResults; // will contain list of results
 
     constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService) {
         this._pending.getListOfPendingChallenges().subscribe(pendingList => {
@@ -23,6 +24,10 @@ export class ChallengeManagementComponent {
         this._challengeDB.getListOfChallenges().subscribe(challengeList => {
             this.listOfActiveChallenges = challengeList;
             // console.log('list of actives:', this.listOfActiveChallenges);
+        });
+
+        this._pending.getListOfResults().subscribe(resultList => {
+            this.listOfResults = resultList;
         });
     }
 

--- a/src/app/sub-pages/challenges/challenge.component.html
+++ b/src/app/sub-pages/challenges/challenge.component.html
@@ -22,7 +22,14 @@
                  </tbody>
             </table>
         </div>
-    </div>
+    </div> <!-- end row -->
+    <div class="row">
+        <h2 class="text-center">Posting Results</h2>
+        <p>It is the responsibility of the winner of the challenge to post results. If you won and you linked your Google account to your ladder spot,
+            you can submit a result from the user dashboard. Otherwise, you must message an admin on the FGC discord the result of the match. The loser
+            is allowed to submit a result if they have a linked account.
+        </p>
+    </div> <!-- end results row
     <!-- <div class="row">
         <div class="col-sm-8 col-sm-offset-3 wufoo-container">
             <iframe class="wufoo-form" height="620" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none"  src="https://fgcladder.wufoo.com/embed/z8efeqd002fkar/"><a href="https://fgcladder.wufoo.com/forms/z8efeqd002fkar/">Fill out my Wufoo form!</a></iframe><div id="wuf-adv" style="font-family:inherit;font-size: small;color:#a7a7a7;text-align:center;display:block;"></div></div>

--- a/src/app/sub-pages/dashboard/dashboard.component.css
+++ b/src/app/sub-pages/dashboard/dashboard.component.css
@@ -21,4 +21,10 @@
 .dashboard-challenge-item {
     border: 1px solid #000;
     padding-left: 20px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
+.dashboard-post-score-label {
+    margin-right: 20px;
 }

--- a/src/app/sub-pages/dashboard/dashboard.component.html
+++ b/src/app/sub-pages/dashboard/dashboard.component.html
@@ -77,6 +77,9 @@
                 </div>
             </div>
         </div> <!-- end challenge posting row -->
+        <div class="row" *ngIf="submittedResult === true">
+            <h4 class="text-center">Your result has been uploaded and is pending approval.</h4>
+        </div>
     </div> <!-- end challenge status container -->
     <div class="container" *ngIf="allowLink===true">
         <h3 class="text-center font-bangers">Link your account</h3>

--- a/src/app/sub-pages/dashboard/dashboard.component.html
+++ b/src/app/sub-pages/dashboard/dashboard.component.html
@@ -42,6 +42,9 @@
                 <div *ngFor="let challenge of listOfChallenges.att" class="dashboard-challenge-item">
                     <h3>vs. Rank {{ challenge.defenderRank }}: {{ challenge.defenderName }}</h3>
                     <p><strong>Game:</strong> {{ challenge.game }} <strong>Deadline:</strong> {{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
+                    <div class="flex-container justify-center">
+                        <button class="btn btn-info" (click)="postResults(challenge)">Post Results</button>
+                    </div>
                 </div>
             </div> <!-- end left side -->
             <div class="col-sm-6"> <!-- begin right half: defending -->
@@ -53,6 +56,27 @@
                 </div>
             </div> <!-- end right half -->
         </div>
+        <div class="row" *ngIf="allowPost===true"> <!-- begin challenge posting row -->
+            <div class="col-sm-6"> <!-- begin challenger half -->
+                <h3 class="text-center">{{ selectedChallenge.challengerName }}</h3>
+                <div class="flex-container justify-center">
+                    <label class="dashboard-post-score-label">Score: </label>
+                    <input type="number" [(ngModel)]="challengerScore">
+                </div>
+            </div> <!-- end challenger half -->
+            <div class="col-sm-6"> <!-- begin defender half -->
+                <h3 class="text-center">{{ selectedChallenge.defenderName }}</h3>
+                <div class="flex-container justify-center">
+                    <label class="dashboard-post-score-label">Score: </label>
+                    <input type="number" [(ngModel)]="defenderScore">
+                </div>
+            </div> <!-- end defender half -->
+            <div class="col-sm-12">
+                <div class="flex-container justify-center">
+                    <button class="btn btn-info" (click)="submitScores()">Submit Scores for Approval</button>
+                </div>
+            </div>
+        </div> <!-- end challenge posting row -->
     </div> <!-- end challenge status container -->
     <div class="container" *ngIf="allowLink===true">
         <h3 class="text-center font-bangers">Link your account</h3>

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -138,6 +138,8 @@ export class DashboardComponent {
 
     public submitScores() {
         if (confirm(`Confirm Score: ${this.selectedChallenge.challengerName}-${this.challengerScore}, ${this.selectedChallenge.defenderName}-${this.defenderScore}`)) {
+            this.selectedChallenge['challengeDBId'] = this.selectedChallenge.id;
+            this.selectedChallenge.id = null;
             this.selectedChallenge['challengerScore'] = this.challengerScore;
             this.selectedChallenge['defenderScore'] = this.defenderScore;
         }

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -23,10 +23,16 @@ export class DashboardComponent {
         def: []
     };
 
+    // result posting fields
+    public selectedChallenge; // will contain the challenge that the user wants to post a result on
+    public challengerScore: number;
+    public defenderScore: number;
+
     // display flags
     public displaySubmitMessage = false; // pretty self explanatory
     public allowLink = false; // will determine if a player is linking an account
     public linkDupeWarning = false;
+    public allowPost = false; // flag to toggle viewing the posting of challenge results
 
     constructor(public login: LoginService, private _ladderDB: LadderDatabaseService, private _pending: PendingDatabaseService,
     private _challengeDB: ChallengeDatabaseService) {
@@ -122,6 +128,18 @@ export class DashboardComponent {
             this._pending.addPendingLink(linkToBeAdded);
             this.linkDupeWarning = false;
             this.displaySubmitMessage = true;
+        }
+    }
+
+    public postResults(challenge) {
+        this.selectedChallenge = challenge;
+        this.allowPost = true;
+    }
+
+    public submitScores() {
+        if (confirm(`Confirm Score: ${this.selectedChallenge.challengerName}-${this.challengerScore}, ${this.selectedChallenge.defenderName}-${this.defenderScore}`)) {
+            this.selectedChallenge['challengerScore'] = this.challengerScore;
+            this.selectedChallenge['defenderScore'] = this.defenderScore;
         }
     }
 

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -33,6 +33,7 @@ export class DashboardComponent {
     public allowLink = false; // will determine if a player is linking an account
     public linkDupeWarning = false;
     public allowPost = false; // flag to toggle viewing the posting of challenge results
+    public submittedResult = false; // flag to display submitted message
 
     constructor(public login: LoginService, private _ladderDB: LadderDatabaseService, private _pending: PendingDatabaseService,
     private _challengeDB: ChallengeDatabaseService) {
@@ -134,16 +135,23 @@ export class DashboardComponent {
     public postResults(challenge) {
         this.selectedChallenge = challenge;
         this.allowPost = true;
+        this.submittedResult = false;
     }
 
     public submitScores() {
+
         if (confirm(`Confirm Score: ${this.selectedChallenge.challengerName}-${this.challengerScore}, ${this.selectedChallenge.defenderName}-${this.defenderScore}`)) {
             this.selectedChallenge['challengeDBId'] = this.selectedChallenge.id;
             this.selectedChallenge.id = null;
             this.selectedChallenge['challengerScore'] = this.challengerScore;
             this.selectedChallenge['defenderScore'] = this.defenderScore;
-            this._pending.addResult(this.selectedChallenge);
-            this.allowPost = false;
+            if (this._pending.dupeResultCheck(this.selectedChallenge.challengeDBId) === true) {
+                alert(`There's already a result pending approval for this challenge. Contact an admin if you feel this is an error.`);
+            } else {
+                this._pending.addResult(this.selectedChallenge);
+                this.allowPost = false;
+                this.submittedResult = true;
+            }
         }
     }
 

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -35,9 +35,11 @@ export class DashboardComponent {
     public allowPost = false; // flag to toggle viewing the posting of challenge results
     public submittedResult = false; // flag to display submitted message
 
+    // instantiate necessary lists...
     constructor(public login: LoginService, private _ladderDB: LadderDatabaseService, private _pending: PendingDatabaseService,
     private _challengeDB: ChallengeDatabaseService) {
 
+        // ..login info
         this.login.getLoggedInUserObs().map(user => {
             const newUser = {
                 email: user.email,
@@ -92,27 +94,33 @@ export class DashboardComponent {
 
     } // end constructor
 
+    // method to initiate linking a google account to a spot on the ladder. takes in the game ref from the appropriatte entry
     public beginLink(game: string) {
         this.selectedGame = game;
         this.allowLink = true;
-
+        // instantiate list of players for selected game
         this._ladderDB.getPlayers(game).subscribe(playerList => {
             this.listOfPlayers = playerList;
         });
     }
 
+    // method to cancel linking account
     public cancelLink() {
         this.selectedGame = null;
         this.allowLink = false;
     }
 
+    // method of making sure a player has a google account. this is used to make sure someone doesnt overwrite a listing that already
+    // has a google account
     public hasGoogle(index: number) {
         if (this.listOfPlayers[index].google) {return true;
         } else {return false; }
     }
 
+    // method to actually link the player to a google account
     public linkPlayer(id: string, name: string) {
 
+        // create player object
         const linkToBeAdded = {
             playerId: id,
             game: this.selectedGame,
@@ -120,34 +128,44 @@ export class DashboardComponent {
             name: name,
             email: this._user.email
         };
-        console.log('dupe check comp side:', this._pending.dupeLinkCheck(this.selectedGame, id));
+        // console.log('dupe check comp side:', this._pending.dupeLinkCheck(this.selectedGame, id));
+        // make sure that theres not already a pending request to link this listing
         if (this._pending.dupeLinkCheck(this.selectedGame, id) === true) {
+            // show dupe warning if thats the case
             this.linkDupeWarning = true;
             return;
         } else if (confirm(`Are you sure you want to link ${name} to your google account?`)) {
-
+            // call method to link accounr, reset flags
             this._pending.addPendingLink(linkToBeAdded);
             this.linkDupeWarning = false;
             this.displaySubmitMessage = true;
         }
     }
 
+    // method to allow user to begin entering results
     public postResults(challenge) {
+        // designate appropraite challenge and set flags
         this.selectedChallenge = challenge;
         this.allowPost = true;
         this.submittedResult = false;
     }
 
+    // method to submit score for approval
     public submitScores() {
 
         if (confirm(`Confirm Score: ${this.selectedChallenge.challengerName}-${this.challengerScore}, ${this.selectedChallenge.defenderName}-${this.defenderScore}`)) {
+            // assign values from fields into challenge object
+            // retain the ID from the challenge database so we can delete the challenge upon approving the score
             this.selectedChallenge['challengeDBId'] = this.selectedChallenge.id;
+            // then reset the id so it can be filled with the id given in the pending results list
             this.selectedChallenge.id = null;
             this.selectedChallenge['challengerScore'] = this.challengerScore;
             this.selectedChallenge['defenderScore'] = this.defenderScore;
+            // make sure there isn't already a score submission for this challenge
             if (this._pending.dupeResultCheck(this.selectedChallenge.challengeDBId) === true) {
                 alert(`There's already a result pending approval for this challenge. Contact an admin if you feel this is an error.`);
             } else {
+                // call method in service to add result to the database
                 this._pending.addResult(this.selectedChallenge);
                 this.allowPost = false;
                 this.submittedResult = true;

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -142,6 +142,8 @@ export class DashboardComponent {
             this.selectedChallenge.id = null;
             this.selectedChallenge['challengerScore'] = this.challengerScore;
             this.selectedChallenge['defenderScore'] = this.defenderScore;
+            this._pending.addResult(this.selectedChallenge);
+            this.allowPost = false;
         }
     }
 

--- a/src/app/sub-pages/place-challenge/place-challenge.component.ts
+++ b/src/app/sub-pages/place-challenge/place-challenge.component.ts
@@ -147,6 +147,7 @@ export class PlaceChallengeComponent {
     public submitChallenge() {
         // challenge error codes: 0 - challenge valid, 1 - defender already has a challenge pending,
         // 2 - attacker already has a challenge pending, 3 - defender has one from DB, 4 - attacker has one from db
+        // 5 - challenger is trying to challenge the same player twice in a row, 6 - challenger is rank 2 and challenging the champ too soon
 
         // validation
         let challengeErrorCode = 0;
@@ -168,6 +169,16 @@ export class PlaceChallengeComponent {
                 if (challenge.defenderId === this.selectedDefender.id) { challengeErrorCode = 3; }
                 if (challenge.challengerId === this.selectedChallenger.id) { challengeErrorCode = 4; }
             });
+        }
+
+        // make sure the challenger isn't challenging the same opponent twice in a row.. unless they are rank 2
+        if (this.selectedChallenger.recentOpponent === this.selectedDefender.id && this.selectedChallenger.rank !== 2) {
+            challengeErrorCode = 5;
+        }
+
+        // make sure opponent isnt rank 2 and challenging the opponent too early
+        if (this.selectedChallenger.rank === 2 && this.selectedChallenger.champWait < Date.now()) {
+            challengeErrorCode = 6;
         }
 
         switch (challengeErrorCode) {
@@ -227,6 +238,12 @@ export class PlaceChallengeComponent {
             case 4:
                 console.log('attacker has Challenge in DB');
                 alert(`The attacker ${this.selectedChallenger.name} already has a challenge posted and waiting to complete`);
+                break;
+            case 5:
+                alert('Challenger is trying to challenge the same opponent twice in a row');
+                break;
+            case 6:
+                alert('Challenger is challenging the champ too soon after a failed attempt');
                 break;
             default:
                 console.log('Unknown error code passed. ');

--- a/src/app/sub-pages/place-challenge/place-challenge.component.ts
+++ b/src/app/sub-pages/place-challenge/place-challenge.component.ts
@@ -251,7 +251,7 @@ export class PlaceChallengeComponent {
         }
 
 
-        
+
     }
 
     public startOver() {

--- a/src/app/sub-pages/standings/standings.component.ts
+++ b/src/app/sub-pages/standings/standings.component.ts
@@ -23,11 +23,13 @@ export class StandingsComponent {
     constructor(public masterLadder: LadderService, private _ladderDB: LadderDatabaseService) {
         this.listOfPlayers = {};
 
+        // instantiate list of player then sort by rank ascending
         this._ladderDB.getGameList().subscribe(gameList => {
             this.listOfGames = gameList;
             this.listOfGames.forEach(game => {
                 this._ladderDB.getPlayers(game.ref).subscribe(playerList => {
                     this.listOfPlayers[game.ref] = playerList;
+                    this.listOfPlayers[game.ref].sort(function(a, b) { return a.rank - b.rank; });
                 });
             });
         });


### PR DESCRIPTION
Feature: Result posting! Users with a linked account can now post results from their dashboard. The result is then sent to the database where an admin can approve it. Upon approval, the necessary stats are updated on the ladder and the challenge is cleared. 

I also added a validation on placing a challenge where a user cannot challenge the same player twice in a row... unless they are rank 2 in which case they have no choice.

Bugfix: The list of players on the standings display is now sorted by rank by default.

Known issue: Streak is not updated along with the other results. that will take some creative thinking lol