### PR TITLE
Match history

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { NewsService } from './services/news-service';
 import { LoginService } from './services/login.service';
 import { PendingDatabaseService } from './services/database/pending-database.service';
 import { ChallengeDatabaseService } from './services/database/challenge-database.service';
+import { MatchHistoryDatabaseService } from './services/database/match-history-database.service';
 
 
 @NgModule({
@@ -34,7 +35,7 @@ import { ChallengeDatabaseService } from './services/database/challenge-database
     AngularFireAuthModule, AngularFireDatabaseModule
   ],
   providers: [ TwitchStatusService, LadderService, MatchHistoryService, ChallengeListService, NewsService, LoginService,
-    PendingDatabaseService, ChallengeDatabaseService ],
+    PendingDatabaseService, ChallengeDatabaseService, MatchHistoryDatabaseService ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -87,7 +87,8 @@
                             <p>Recent Matches</p>
                         </div>
                         <div class="sidebar-panel-body text-center">
-                            <p *ngFor="let match of recentMatches">{{match.date}}: {{match.winnerName}} def. {{match.loserName}} {{match.wins}}-{{match.losses}}</p>
+                            <!-- <p *ngFor="let match of recentMatches">{{match.date}}: {{match.winnerName}} def. {{match.loserName}} {{match.wins}}-{{match.losses}}</p> -->
+                            <p *ngFor="let match of listOfMatches">{{ match.dateCompleted | date: 'MM/dd'}}: {{ match.challengerName }} {{ match.challengerScore }} - {{ match.defenderScore }} {{ match.defenderName }} ({{ match.game }})</p>
                         </div>
                     </div> <!-- End Recent sidebar container -->
                 </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -74,11 +74,13 @@ export class HomeComponent implements AfterViewInit {
             for (let i = matches.length - 1; i >= 0; i--) {
                 if (Date.now() - matches[i]['dateCompleted'] > this._MATCHTIME) {
                     matches.splice(i, 1);
+                } else {
+                    matches[i]['dateCompleted'] = this.unixDateConv(matches[i]['dateCompleted']);
                 }
             }
             return matches;
         }).subscribe(matches => {
-            console.log('recent match list:', matches);
+            this.listOfMatches = matches;
         });
     }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -10,6 +10,7 @@ import { MatchHistoryService } from './../services/match-history.service';
 import { NewsService } from './../services/news-service';
 import { NewsDatabaseService } from './../services/database/news-databse.service';
 import { ChallengeDatabaseService } from './../services/database/challenge-database.service';
+import { MatchHistoryDatabaseService } from './../services/database/match-history-database.service';
 
 @Component({
     selector: 'app-home',
@@ -35,13 +36,17 @@ export class HomeComponent implements AfterViewInit {
     public listOfStreams: string[];
     public streamInfo;
     public listOfChallenges; // will contain list of challenges
+    public listOfMatches; // will contain matchlist
+
+    public _MATCHTIME = 1209600000; // how far back we want to display matches on the front page.. in milliseconds...
 
     constructor(
         public twitchStatus: TwitchStatusService,
         private matchList: MatchHistoryService,
         private news: NewsService,
         private _newsData: NewsDatabaseService,
-        private _challengeDB: ChallengeDatabaseService
+        private _challengeDB: ChallengeDatabaseService,
+        private _matchDB: MatchHistoryDatabaseService
     ) {
 
         // List of Stream to be shown on front page
@@ -60,6 +65,20 @@ export class HomeComponent implements AfterViewInit {
 
         this.databaseTheRest.subscribe( data => {
             // console.log('older news from database service', data);
+        });
+
+        // get list of matches and remove matches that are over 2 weeks old
+        // make sure to go through the list backwards to avoid skips in the index
+        // NOTE: the list NEEDS to be sort my date in ascending order
+        this._matchDB.getListOfMatches().map(matches => {
+            for (let i = matches.length - 1; i >= 0; i--) {
+                if (Date.now() - matches[i]['dateCompleted'] > this._MATCHTIME) {
+                    matches.splice(i, 1);
+                }
+            }
+            return matches;
+        }).subscribe(matches => {
+            console.log('recent match list:', matches);
         });
     }
 

--- a/src/app/services/database/ladder-database.service.ts
+++ b/src/app/services/database/ladder-database.service.ts
@@ -55,6 +55,9 @@ export class LadderDatabaseService {
                 playerList.push(playerLoop);
             }
             // console.log('list of players from service with id:', playerList);
+            playerList.sort(function(a, b) {
+                return a.rank - b.rank;
+            });
             return playerList;
         });
     } // end get players

--- a/src/app/services/database/match-history-database.service.ts
+++ b/src/app/services/database/match-history-database.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { AngularFireDatabase } from 'angularfire2/database';
+
+import { AngularFireList, AngularFireObject, FirebaseOperation } from 'angularfire2/database/interfaces';
+
+@Injectable()
+
+export class MatchHistoryDatabaseService {
+
+    constructor (private _database: AngularFireDatabase) {}
+
+    public addMatch(match) {
+        this._database.list('/y-match-history').push(match);
+    }
+
+    public deleteMatch(id) {
+        this._database.list('/y-match-history').remove(id);
+    }
+
+    public getListOfMatches() {
+        return this._database.list('/y-match-history').valueChanges().map( matchList => {
+
+            const listOfKeys = [];
+            this._database.list('/y-match-history/').snapshotChanges().subscribe(snapshotList => {
+                snapshotList.forEach(function(snapshot) {
+                    listOfKeys.push(snapshot.key);
+                });
+                matchList.forEach(function(pendingItem, index) {matchList[index]['id'] = listOfKeys[index]; });
+            });
+            return matchList;
+        });
+    }
+}

--- a/src/app/services/database/match-history-database.service.ts
+++ b/src/app/services/database/match-history-database.service.ts
@@ -29,6 +29,8 @@ export class MatchHistoryDatabaseService {
                 });
                 matchList.forEach(function(pendingItem, index) {matchList[index]['id'] = listOfKeys[index]; });
             });
+            // sort matched in descending order by datecompleted
+            matchList.sort(function(a, b) { return b['dateCompleted'] - a['dateCompleted']; });
             return matchList;
         });
     }

--- a/src/app/sub-pages/admin/admin.component.html
+++ b/src/app/sub-pages/admin/admin.component.html
@@ -6,6 +6,7 @@
     <button class="btn btn-danger" routerLink="./players">Add/Remove Players</button>
     <button class="btn btn-danger" routerLink="./pending">Pending Joins</button>
     <button class="btn btn-danger" routerLink="./pending-link">Pending Link Requests</button>
+    <button class="btn btn-danger" routerLink="./match-history">Match History</button>
 </div>
 <hr>
 <router-outlet></router-outlet>

--- a/src/app/sub-pages/admin/admin.routing.module.ts
+++ b/src/app/sub-pages/admin/admin.routing.module.ts
@@ -9,6 +9,7 @@ import { ChallengeManagementComponent } from './challenge-management/challenge-m
 import { PlayerManagementComponent } from './player-management/player-management.component';
 import { PendingManagementComponent } from './pending-management/pending-management.component';
 import { LinkManagementComponent } from './link-management/link-management.component';
+import { MatchHistoryManagementComponent } from './match-history-management/match-history-management';
 
 const routes: Routes = [{
         path: 'admin',
@@ -34,6 +35,10 @@ const routes: Routes = [{
         {
             path: 'pending-link',
             component: LinkManagementComponent
+        },
+        {
+            path: 'match-history',
+            component: MatchHistoryManagementComponent
         }]
 
 }];
@@ -47,4 +52,4 @@ const routes: Routes = [{
 export class AdminRoutingModule {}
 
 export const RoutingComponents =  [NewsManagementComponent, PlayerManagementComponent, ChallengeManagementComponent,
-    PendingManagementComponent, LinkManagementComponent];
+    PendingManagementComponent, LinkManagementComponent, MatchHistoryManagementComponent];

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -45,9 +45,23 @@
                 <p>{{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
             </div>
             <div class="col-sm-1 challenge-pending-min-height challenge-pending-item-buttons">
+                <button class="btn btn-success" (click)="addScore(challenge)">Edit Score</button>
                 <button class="btn btn-danger" (click)="deleteActiveChallenge(challenge.id)">Delete</button>
             </div>
         </div> <!-- end looped active challenge row -->
+        <div class="row" *ngIf="editScore === true"> <!-- begin score edit div -->
+            <div class="col-sm-3 col-sm-offset-3">
+                <label>Challenger Score: </label>
+                <input type="number" [(ngModel)]="challengerScoreInput">
+            </div>
+            <div class="col-sm-3">
+                <label>Defender Score: </label>
+                <input type="number" [(ngModel)]="defenderScoreInput">
+            </div>
+            <div class="col-sm-12 flex-container justify-center">
+                <button class="btn btn-info" (click)="submitScore()">Submit Score</button>
+            </div>
+        </div> <!-- end score edit div -->
         <div class="row"> <!-- begin result title row -->
             <div class="col-sm-12">
                 <h3 class="text-center font-bangers">List of results needing approval</h3>

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -19,6 +19,12 @@ export class ChallengeManagementComponent {
     public listOfAffectedPlayers; // will container players on a ladder whos rank will change
     private _currentDefender; // will contain the player which is defending a challenge for purpose of result posting
     private _postButtonClicked = false; // flag to make sure post button was clicked. more explanation on result posting function
+    public editScore = false; // is the user editing score?
+    public selectedChallenge;
+
+    // ngmodel fields
+    public challengerScoreInput: string;
+    public defenderScoreInput: string;
 
     constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService,
         private _ladderDB: LadderDatabaseService, private _matchDB: MatchHistoryDatabaseService) {
@@ -70,6 +76,22 @@ export class ChallengeManagementComponent {
         }
     }
 
+    public addScore(challenge) {
+        this.editScore = true;
+        this.selectedChallenge = challenge;
+    }
+
+    public submitScore() {
+        if (confirm('Are you sure you want to submit this score? This will not erase the challenge from the DB.')) {
+            this.selectedChallenge['challengerScore'] = this.challengerScoreInput;
+            this.selectedChallenge['defenderScore'] = this.defenderScoreInput;
+            this.selectedChallenge['challengeDBId'] = this.selectedChallenge.id;
+            this.selectedChallenge.id = null;
+            this._pending.addResult(this.selectedChallenge);
+            this.editScore = false;
+        }
+
+    }
 
     // method to approve result. note that because we are using a subscription to valuechanges, this will run EACH TIME
     // an edit is made on a player. in order to prevent that, we want to make sure that it runs only once, and only when
@@ -134,6 +156,7 @@ export class ChallengeManagementComponent {
         // we should also adjust the defenders rank if thats the case
         if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
             this.listOfAffectedPlayers.shift();
+            this._currentDefender.rank++;
         }
 
         console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -109,6 +109,8 @@ export class ChallengeManagementComponent {
 
                 // make sure we're coming from the challenge management page with this flag check
                 if (this._postButtonClicked === true) {
+                    // sort list by rank lol
+
                     this._currentDefender = playerList.find(function(e, i, a) {
                         if (e.id === result.defenderId) { return true; }
                     });
@@ -137,7 +139,10 @@ export class ChallengeManagementComponent {
     private _winAdjust(result, chall) {
 
         // increment all affected players rank by 1
-        this.listOfAffectedPlayers.forEach(player => { player.rank++; });
+        this.listOfAffectedPlayers.forEach(player => {
+            console.log('hunch: incrementing affected players rank');
+            player.rank++;
+        });
         // then readjust challengers rank based on the challenge data
         this.listOfAffectedPlayers[chall].rank = result.defenderRank;
 
@@ -155,20 +160,20 @@ export class ChallengeManagementComponent {
         // if current defender is actually in the afectedPlayers list, he should always be first so a simple shift() should work
         // we should also adjust the defenders rank if thats the case
         if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
+            // console.log('shifting selected players. oldlist', this.listOfAffectedPlayers);
             this.listOfAffectedPlayers.shift();
-            this._currentDefender.rank++;
+            // console.log('new list', this.listOfAffectedPlayers);
+            // this._currentDefender.rank++;
         }
 
         console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);
         // finally, push adjustments to db
-        this.listOfAffectedPlayers.forEach(player => {
-            // update affected players
-        });
 
         // update defender and delete challenge and result from database. also reset the clicked button flag
         this._ladderDB.challengerWinPost(this.listOfAffectedPlayers, this._currentDefender, result);
         // set current date in unix and push to match history
         result.dateCompleted = Date.now();
+
         this._matchDB.addMatch(result);
         this._challengeDB.deleteChallenge(result.challengeDBId);
         this._pending.deleteResult(result.id);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { PendingDatabaseService } from './../../../services/database/pending-database.service';
 import { ChallengeDatabaseService } from './../../../services/database/challenge-database.service';
 import { LadderDatabaseService } from './../../../services/database/ladder-database.service';
+import { MatchHistoryDatabaseService } from './../../../services/database/match-history-database.service';
 
 @Component({
     selector: 'app-admin-news',
@@ -20,7 +21,7 @@ export class ChallengeManagementComponent {
     private _postButtonClicked = false; // flag to make sure post button was clicked. more explanation on result posting function
 
     constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService,
-        private _ladderDB: LadderDatabaseService) {
+        private _ladderDB: LadderDatabaseService, private _matchDB: MatchHistoryDatabaseService) {
         this._pending.getListOfPendingChallenges().subscribe(pendingList => {
             this.listOfPendingChallenges = pendingList;
             // onsole.log('list of pendings:', this.listOfPendingChallenges);
@@ -143,6 +144,9 @@ export class ChallengeManagementComponent {
 
         // update defender and delete challenge and result from database. also reset the clicked button flag
         this._ladderDB.challengerWinPost(this.listOfAffectedPlayers, this._currentDefender, result);
+        // set current date in unix and push to match history
+        result.dateCompleted = Date.now();
+        this._matchDB.addMatch(result);
         this._challengeDB.deleteChallenge(result.challengeDBId);
         this._pending.deleteResult(result.id);
         this._postButtonClicked = false;
@@ -172,6 +176,9 @@ export class ChallengeManagementComponent {
         // console.log('post defender win adjustments', this._currentDefender, this.listOfAffectedPlayers[chall]);
         // update results
         this._ladderDB.defenderWinPost(this.listOfAffectedPlayers[chall], this._currentDefender, result);
+        // set current date in unix and push to match history
+        result.dateCompleted = Date.now();
+        this._matchDB.addMatch(result);
         // remove result and challenge from database
         this._challengeDB.deleteChallenge(result.challengeDBId);
         this._pending.deleteResult(result.id);

--- a/src/app/sub-pages/admin/match-history-management/match-history-management.css
+++ b/src/app/sub-pages/admin/match-history-management/match-history-management.css
@@ -1,0 +1,3 @@
+.match-history-item {
+    border: 1px solid #660000;
+}

--- a/src/app/sub-pages/admin/match-history-management/match-history-management.html
+++ b/src/app/sub-pages/admin/match-history-management/match-history-management.html
@@ -1,0 +1,3 @@
+<div>
+    <h1 class="text-center font-bangers">Match History Management</h1>
+</div>

--- a/src/app/sub-pages/admin/match-history-management/match-history-management.html
+++ b/src/app/sub-pages/admin/match-history-management/match-history-management.html
@@ -1,3 +1,15 @@
-<div>
+<div class="font-titi">
     <h1 class="text-center font-bangers">Match History Management</h1>
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-4" *ngFor="let match of listOfMatches">
+                <div class="text-center match-history-item">
+                    <p>Game: {{match.game}}</p>
+                    <h4>({{match.challengerRank}}) {{match.challengerName}} {{match.challengerScore}} - {{match.defenderScore}} {{match.defenderName}} ({{match.defenderRank}})</h4>
+                    <p>{{match.dateCompleted | date: 'fullDate'}}</p>
+                    <button class="btn btn-danger" (click)="deleteMatch(match.id)">Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/sub-pages/admin/match-history-management/match-history-management.ts
+++ b/src/app/sub-pages/admin/match-history-management/match-history-management.ts
@@ -8,4 +8,19 @@ import { MatchHistoryDatabaseService } from './../../../services/database/match-
     styleUrls: [ './match-history-management.css']
 })
 
-export class MatchHistoryManagementComponent {}
+export class MatchHistoryManagementComponent {
+
+    public listOfMatches;
+
+    constructor(private _matchDB: MatchHistoryDatabaseService) {
+        this._matchDB.getListOfMatches().subscribe(matchList => {
+            this.listOfMatches = matchList;
+        });
+    }
+
+    public deleteMatch(id) {
+        if (confirm('Are you sure you want to delete this match from the database?')) {
+            this._matchDB.deleteMatch(id);
+        }
+    }
+}

--- a/src/app/sub-pages/admin/match-history-management/match-history-management.ts
+++ b/src/app/sub-pages/admin/match-history-management/match-history-management.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+import { MatchHistoryDatabaseService } from './../../../services/database/match-history-database.service';
+
+@Component({
+    selector: 'app-admin-match-history',
+    templateUrl: './match-history-management.html',
+    styleUrls: [ './match-history-management.css']
+})
+
+export class MatchHistoryManagementComponent {}

--- a/src/app/sub-pages/match-history/match-history.component.html
+++ b/src/app/sub-pages/match-history/match-history.component.html
@@ -3,14 +3,14 @@
     <div class="row">
         <div class="col-sm-12">
             <div class="list-group match-results">
-              <p *ngIf="recordDisplay.length < 1">ERROR: No Match records available to display :(</p>
-              <div *ngFor="let match of recordDisplay" class="match-history-row">
+              <p *ngIf="listOfMatches?.length < 1">ERROR: No Match records available to display :(</p>
+              <div *ngFor="let match of listOfMatches" class="match-history-row">
                   <div class="match-history-game flex-container justify-center align-center font-bangers">{{ match.game }}</div>
-                  <div class="match-history-date font-bangers text-center">{{ match.date }}</div>
+                  <div class="match-history-date font-bangers text-center">{{ match.dateCompleted | date: 'fullDate' }}</div>
                   <button type="button" class="list-group-item">
-                      <span class="label label-default">Rank {{ match.winnerRank }}</span><strong> {{ match.winnerName }}</strong> ({{ match.winnerChar }})
-                      <span class="font-bangers match-history-score">{{ match.wins }} : {{ match.losses }}</span>
-                      <strong> {{ match.loserName }}</strong> ({{ match.loserChar }}) <span class="label label-default">Rank {{ match.loserRank }}</span>
+                      <span class="label label-default">Rank {{ match.challengerRank }}</span><strong> {{ match.challengerName }}</strong>
+                      <span class="font-bangers match-history-score">{{ match.challengerScore }} : {{ match.defenderScore }}</span>
+                      <strong> {{ match.defenderName }}</strong> <span class="label label-default">Rank {{ match.defenderRank }}</span>
                     </button></div>
               
             </div>

--- a/src/app/sub-pages/match-history/match-history.component.ts
+++ b/src/app/sub-pages/match-history/match-history.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import MatchRecord from './../../interfaces/match-record';
 import { MatchHistoryService } from './../../services/match-history.service';
+import { MatchHistoryDatabaseService } from './../../services/database/match-history-database.service';
 
 @Component({
     selector: 'app-match-history',
@@ -10,12 +11,15 @@ import { MatchHistoryService } from './../../services/match-history.service';
 
 export class MatchHistoryComponent {
 
-
+    public listOfMatches;
     public recordDisplay: MatchRecord[] = [];
 
-    constructor(private historyList: MatchHistoryService) {
+    constructor(private historyList: MatchHistoryService, private _matchDB: MatchHistoryDatabaseService) {
         for (let i = 0; i < this.historyList.getMatchListLength(); i++) {
             this.recordDisplay.push(this.historyList.getMatchRecord(i));
         }
+        this._matchDB.getListOfMatches().subscribe(matchList => {
+            this.listOfMatches = matchList;
+        });
     }
 }


### PR DESCRIPTION
Feature: Match history! Any complete matches are now pushed to the database and displayed both on the front page and the match history page. The front page only displays matches from the past two week. Admins can delete matches from the database in the new match-history management page in the admin menu, Admins can now also post scores from anonymous challenges, I don't know why I forgot that feature in the last update.

BugFix: Ranks weren't properly adjusting after posting scores. There may be a bug or two but I think I got it. To that end, all lists of players gotten from the database are sorted by ascending rank by default. That solved a few problems right there.