### PR TITLE
Streak edit

### DIFF
--- a/src/app/services/database/ladder-database.service.ts
+++ b/src/app/services/database/ladder-database.service.ts
@@ -152,7 +152,8 @@ export class LadderDatabaseService {
         dbRef.update(def.id, {
             losses: def.losses,
             elo: def.elo,
-            rank: def.rank
+            rank: def.rank,
+            streak: def.streak
         });
 
         // update everyone in the list of affected players array
@@ -162,7 +163,8 @@ export class LadderDatabaseService {
             dbRef.update(chall.id, {
                 wins: chall.wins,
                 elo: chall.elo,
-                rank: chall.rank
+                rank: chall.rank,
+                streak: chall.streak
             });
         });
     }
@@ -175,14 +177,16 @@ export class LadderDatabaseService {
         // update defender stats. only wins and elo should be adjusted
         dbRef.update(def.id, {
             wins: def.wins,
-            elo: def.elo
+            elo: def.elo,
+            streak: def.streak
         });
 
         // update challenger. losses, elo, and recent player should be adjusted
         dbRef.update(chall.id, {
             losses: chall.losses,
             elo: chall.elo,
-            recentOpponent: chall.recentOpponent
+            recentOpponent: chall.recentOpponent,
+            streak: chall.streak
         });
     }
 

--- a/src/app/services/database/pending-database.service.ts
+++ b/src/app/services/database/pending-database.service.ts
@@ -208,4 +208,14 @@ export class PendingDatabaseService {
         });
         return dupeCheck;
     }
+
+    public isResultPending(challId, defId) {
+        let endResult = false;
+        this._listOfResults.forEach(result => {
+            if (result.challengerId === challId && result.defenderId === defId ) {
+                endResult = true;
+            }
+        });
+        return endResult;
+    }
 }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -231,4 +231,52 @@ export class ChallengeManagementComponent {
         return new Date(unix);
     }
 
+    // method to update a players streak field. takes a string of the old stream and a number denoting result
+    // 0 == loss, 1 = win
+    private _streakUpdate(oldStreak: string, result: number): string {
+
+        let resultStreak = '';
+        // if the result is a win...
+        if (result === 1) {
+
+            // check to see if the current streak is a win
+            if (oldStreak.charAt(0) === 'W') {
+                // if so find the space in the string
+                const space = oldStreak.search(' ');
+                // grab everything in the result after the space
+                const oldNum = oldStreak.substr(space + 1);
+                // increment it
+                const newNum = parseInt(oldNum, 10) + 1;
+                // create a new streak with an incremented number
+                resultStreak = 'Won '.concat(newNum.toString());
+            } else if (oldStreak.charAt(0) === 'L' || oldStreak.charAt(0) === 'N') {
+                // if previous streak is a loss, reset to one win
+                resultStreak = 'Won 1';
+            } else {
+                console.log('Error, invalid original streak');
+            }
+        } else if (result === 0 ) {
+            // loss would be the inverse of the win effect
+            // check to see if the current streak is a win
+            if (oldStreak.charAt(0) === 'L') {
+                // if so find the space in the string
+                const space = oldStreak.search(' ');
+                // grab everything in the result after the space
+                const oldNum = oldStreak.substr(space + 1);
+                // increment it
+                const newNum = parseInt(oldNum, 10) + 1;
+                // create a new streak with an incremented number
+                resultStreak = 'Lost '.concat(newNum.toString());
+            } else if (oldStreak.charAt(0) === 'W' || oldStreak.charAt(0) === 'N') {
+                // if previous streak is a loss, reset to one win
+                resultStreak = 'Lost 1';
+            } else {
+                console.log('Error, invalid original streak');
+            }
+        } else {
+            console.log('invalid number in result argument, should be 1 or 0');
+        }
+        return resultStreak;
+    }
+
 }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { PendingDatabaseService } from './../../../services/database/pending-database.service';
 import { ChallengeDatabaseService } from './../../../services/database/challenge-database.service';
@@ -11,7 +11,7 @@ import { MatchHistoryDatabaseService } from './../../../services/database/match-
     styleUrls: [ './challenge-management.component.css' ]
 })
 
-export class ChallengeManagementComponent {
+export class ChallengeManagementComponent implements OnInit {
 
     public listOfPendingChallenges; // will contain a list of anon chasllenges that are pending
     public listOfActiveChallenges; // will conatin a list of active challenges
@@ -26,8 +26,7 @@ export class ChallengeManagementComponent {
     public challengerScoreInput: string;
     public defenderScoreInput: string;
 
-    constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService,
-        private _ladderDB: LadderDatabaseService, private _matchDB: MatchHistoryDatabaseService) {
+    ngOnInit() {
         this._pending.getListOfPendingChallenges().subscribe(pendingList => {
             this.listOfPendingChallenges = pendingList;
             // onsole.log('list of pendings:', this.listOfPendingChallenges);
@@ -41,6 +40,11 @@ export class ChallengeManagementComponent {
         this._pending.getListOfResults().subscribe(resultList => {
             this.listOfResults = resultList;
         });
+    }
+
+    constructor (private _pending: PendingDatabaseService, private _challengeDB: ChallengeDatabaseService,
+        private _ladderDB: LadderDatabaseService, private _matchDB: MatchHistoryDatabaseService) {
+
     }
 
     // method to deny challenge. deletes it from the pending list

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -21,6 +21,7 @@ export class ChallengeManagementComponent implements OnInit {
     private _postButtonClicked = false; // flag to make sure post button was clicked. more explanation on result posting function
     public editScore = false; // is the user editing score?
     public selectedChallenge;
+    private _CHALLENGETIME = 604800000; // how long a challenge has to be completed after approval, in milliseconds
 
     // ngmodel fields
     public challengerScoreInput: string;
@@ -56,7 +57,7 @@ export class ChallengeManagementComponent implements OnInit {
     public approveChallenge(challenge, id) {
         if (confirm('Confirm adding selected challenge to official challenge list')) {
             // add 10 days in ubnix time to the current date to pass correct deadling
-            challenge['deadline'] = Date.now() + 864000000;
+            challenge['deadline'] = Date.now() + this._CHALLENGETIME;
             this._pending.deletePendingChallenge(id);
             challenge.id = null; // remove the challenge id from the pending list so that its not confused with the id in the challenge list
             console.log('submitting challenge:', challenge);

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -150,6 +150,10 @@ export class ChallengeManagementComponent {
         this._currentDefender.losses++;
         this.listOfAffectedPlayers[chall].wins++;
 
+        // adjust streak
+        this._currentDefender.streak = this._streakUpdate(this._currentDefender.streak, 1);
+        this.listOfAffectedPlayers[chall].streak = this._streakUpdate(this.listOfAffectedPlayers[chall].streak, 0);
+
         // adjust ELO
         const challELO = this.listOfAffectedPlayers[chall].elo;
         const defELO = this._currentDefender.elo;

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -244,7 +244,7 @@ export class ChallengeManagementComponent implements OnInit {
     // method to update a players streak field. takes a string of the old stream and a number denoting result
     // 0 == loss, 1 = win
     private _streakUpdate(oldStreak: string, result: number): string {
-
+        // console.log('running streak adjust with following arguments', oldStreak, result);
         let resultStreak = '';
         // if the result is a win...
         if (result === 1) {

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -151,8 +151,8 @@ export class ChallengeManagementComponent {
         this.listOfAffectedPlayers[chall].wins++;
 
         // adjust streak
-        this._currentDefender.streak = this._streakUpdate(this._currentDefender.streak, 1);
-        this.listOfAffectedPlayers[chall].streak = this._streakUpdate(this.listOfAffectedPlayers[chall].streak, 0);
+        this._currentDefender.streak = this._streakUpdate(this._currentDefender.streak, 0);
+        this.listOfAffectedPlayers[chall].streak = this._streakUpdate(this.listOfAffectedPlayers[chall].streak, 1);
 
         // adjust ELO
         const challELO = this.listOfAffectedPlayers[chall].elo;
@@ -162,12 +162,10 @@ export class ChallengeManagementComponent {
 
         // make sure defender isnt included in both affectedPlayers and currentDefender
         // if current defender is actually in the afectedPlayers list, he should always be first so a simple shift() should work
-        // we should also adjust the defenders rank if thats the case
         if (this._currentDefender.id === this.listOfAffectedPlayers[0].id) {
             // console.log('shifting selected players. oldlist', this.listOfAffectedPlayers);
             this.listOfAffectedPlayers.shift();
             // console.log('new list', this.listOfAffectedPlayers);
-            // this._currentDefender.rank++;
         }
 
         console.log('post win defender adjustments', this.listOfAffectedPlayers, this._currentDefender);
@@ -198,6 +196,10 @@ export class ChallengeManagementComponent {
         const defELO = this._currentDefender.elo;
         this.listOfAffectedPlayers[chall].elo = this._getNewRating(challELO, defELO, 0);
         this._currentDefender.elo = this._getNewRating(defELO, challELO, 1);
+
+        // adjust streak
+        this._currentDefender.streak = this._streakUpdate(this._currentDefender.streak, 1);
+        this.listOfAffectedPlayers[chall].streak = this._streakUpdate(this.listOfAffectedPlayers[chall].streak, 0);
 
         // if the challenger rank is #2, force them to wait a couple days to place another challenge so that they can't
         // constantly have a lock on the title shot. we'll give them 3 days, 259200000 seconds

--- a/src/app/sub-pages/admin/news-management/news-management.component.html
+++ b/src/app/sub-pages/admin/news-management/news-management.component.html
@@ -1,6 +1,6 @@
 <div class="font-titi">
     <h3 class="text-center font-bangers">News Management</h3>
-    <p class="text-center">You have {{ newsList?.length || 'no' }} news items in the database thus far.</p>
+    <p class="text-center">You have {{ newsListWithId?.length || 'no' }} news items in the database thus far.</p>
     <!-- Begin list of items from database -->
     <div class="container-fluid">
         <div class="row">

--- a/src/app/sub-pages/admin/news-management/news-management.component.ts
+++ b/src/app/sub-pages/admin/news-management/news-management.component.ts
@@ -17,7 +17,6 @@ import NewsItem from './../../../interfaces/news-item';
 
 export class NewsManagementComponent implements OnInit {
 
-    public newsTotal = this.news.getNewsLength();
     public newsList = [];
     public newsListWithId = [];
 
@@ -34,14 +33,14 @@ export class NewsManagementComponent implements OnInit {
     public todaysDate = new Date();
     private _days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-    constructor( public news: NewsService, private _newsData: NewsDatabaseService) {
+    constructor(private _newsData: NewsDatabaseService) {
 
 
     }
 
     ngOnInit() {
 
-        const lol = this._newsData.getNews()
+        this._newsData.getNews()
         .map(data => {
             data.sort(function(a, b) { return b.dateUnix - a.dateUnix; } );
             return data.map(newsItem => {
@@ -60,25 +59,7 @@ export class NewsManagementComponent implements OnInit {
             this.newsListWithId = result;
             // console.log('rr method result',this.newsListWithId);
         });
-        // map observable from the service and then subscribe to it via the newslist array
-        this._newsData.newsObservable.map(newslist => {
-            return newslist.map(newsItem => {
 
-                const myNewsItem: NewsItem = {
-                    author: newsItem.author,
-                    date: newsItem.date,
-                    content: newsItem.content.replace('\n', 'LINEBREAK')
-                };
-                return myNewsItem;
-            });
-        })
-        .subscribe( moreNews => {
-            this.newsList = [];
-            this.newsList = this.newsList.concat(moreNews);
-            console.log('from news base component', this.newsList);
-        });
-
-        
     }
 
     // method for submitting a new news item via form
@@ -90,7 +71,7 @@ export class NewsManagementComponent implements OnInit {
             dateUnix: Date.now(),
             author: formValue.author,
             content: formValue.content
-        }
+        };
 
         // confirm a send before actually pushing to the database
         if (confirm(`Verify sending of news item by ${newsItemToBeSent.author}`)) {
@@ -123,7 +104,7 @@ export class NewsManagementComponent implements OnInit {
 
         this._newsData.getNewsById(id).map(data => {
             // because the data gotten from the service is sent back in array form, we use the map to translate it back to object form
-            // NOTE: this particular method doesnt jive with the NewsItem typing which is why I did not delcared selectedNewsItem 
+            // NOTE: this particular method doesnt jive with the NewsItem typing which is why I did not delcared selectedNewsItem
             // as a :NewsItem above
             const result = {
                 author: data[0],
@@ -136,7 +117,7 @@ export class NewsManagementComponent implements OnInit {
         })
         .subscribe(data => {
             // with the data now transforms into a more readable object we can do stuff with it. First a simple error check with an if
-            if(data) {
+            if (data) {
                 console.log('selected item:', data);
                 // ..then set the selected news item to the entire object
                 this.selectedNewsItem = data;

--- a/src/app/sub-pages/dashboard/dashboard.component.html
+++ b/src/app/sub-pages/dashboard/dashboard.component.html
@@ -39,26 +39,27 @@
             <div class="col-sm-6"> <!-- begin left side: attacking -->
                 <h2 class="text-center">Attacking</h2>
                 <p class="text-center" *ngIf="listOfChallenges.att.length === 0">You are not challenging anyone at this time</p>
-                <div *ngFor="let challenge of listOfChallenges.att" class="dashboard-challenge-item">
+                <div *ngFor="let challenge of listOfChallenges.att" class="dashboard-challenge-item" [ngClass]="{'dashboard-light-red-bg': challenge.isPending === true}">
                     <h3>vs. Rank {{ challenge.defenderRank }}: {{ challenge.defenderName }}</h3>
                     <p><strong>Game:</strong> {{ challenge.game }} <strong>Deadline:</strong> {{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
                     <div class="flex-container justify-around">
-                        <button class="btn btn-info" (click)="postResults(challenge)">Post Results</button>
-                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'c')">Forfeit</button>
+                        <button class="btn btn-info" (click)="postResults(challenge)" [disabled]="challenge.isPending === true">Post Results</button>
+                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'c')" [disabled]="challenge.isPending === true">Forfeit</button>
                     </div>
+                    <h3 *ngIf="challenge.isPending === true" class="text-center">Result Pending Approval</h3>
                 </div>
             </div> <!-- end left side -->
             <div class="col-sm-6"> <!-- begin right half: defending -->
                 <h2 class="text-center">Defending</h2>
                 <p class="text-center" *ngIf="listOfChallenges.def.length === 0">You do not have anyone challenging you at this time.</p>
-                <div *ngFor="let challenge of listOfChallenges.def" class="dashboard-challenge-item">
+                <div *ngFor="let challenge of listOfChallenges.def" class="dashboard-challenge-item" [ngClass]="{'dashboard-light-red-bg': challenge.isPending === true}">
                     <h3>vs. Rank {{ challenge.challengerRank }}: {{ challenge.challengerName }}</h3>
                     <p><strong>Game:</strong> {{ challenge.game }} <strong>Deadline:</strong> {{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
                     <div class="flex-container justify-around">
-                        <button class="btn btn-info" (click)="postResults(challenge)">Post Results</button>
-                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'd')">Forfeit</button>
+                        <button class="btn btn-info" (click)="postResults(challenge)" [disabled]="challenge.isPending === true">Post Results</button>
+                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'd')" [disabled]="challenge.isPending === true">Forfeit</button>
                     </div>
-                </div>
+                    <h3 *ngIf="challenge.isPending === true" class="text-center">Result Pending Approval</h3>
             </div> <!-- end right half -->
         </div>
         <div class="row" *ngIf="allowPost===true"> <!-- begin challenge posting row -->

--- a/src/app/sub-pages/dashboard/dashboard.component.html
+++ b/src/app/sub-pages/dashboard/dashboard.component.html
@@ -42,8 +42,9 @@
                 <div *ngFor="let challenge of listOfChallenges.att" class="dashboard-challenge-item">
                     <h3>vs. Rank {{ challenge.defenderRank }}: {{ challenge.defenderName }}</h3>
                     <p><strong>Game:</strong> {{ challenge.game }} <strong>Deadline:</strong> {{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
-                    <div class="flex-container justify-center">
+                    <div class="flex-container justify-around">
                         <button class="btn btn-info" (click)="postResults(challenge)">Post Results</button>
+                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'c')">Forfeit</button>
                     </div>
                 </div>
             </div> <!-- end left side -->
@@ -53,8 +54,9 @@
                 <div *ngFor="let challenge of listOfChallenges.def" class="dashboard-challenge-item">
                     <h3>vs. Rank {{ challenge.challengerRank }}: {{ challenge.challengerName }}</h3>
                     <p><strong>Game:</strong> {{ challenge.game }} <strong>Deadline:</strong> {{ unixConvert(challenge.deadline) | date: 'fullDate' }}</p>
-                    <div class="flex-container justify-center">
+                    <div class="flex-container justify-around">
                         <button class="btn btn-info" (click)="postResults(challenge)">Post Results</button>
+                        <button class="btn btn-danger" (click)="forfeitChallenge(challenge, 'd')">Forfeit</button>
                     </div>
                 </div>
             </div> <!-- end right half -->

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -199,6 +199,10 @@ export class DashboardComponent {
         }
     }
 
+    public isResultPending(id: string) {
+        return this._pending.dupeResultCheck(id);
+    }
+
     public joinLadder(game) {
         this._router.navigate(['/join', {game: game}]);
     }

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -175,6 +175,27 @@ export class DashboardComponent {
         }
     }
 
+    public forfeitChallenge(challenge: object, playerPos: string) {
+        const pendingResult = challenge;
+        let breakFlag = false;
+        if (playerPos === 'c') {
+            pendingResult['challengerScore'] = 0;
+            pendingResult['defenderScore'] = 5;
+        } else if (playerPos === 'd') {
+            pendingResult['challengerScore'] = 5;
+            pendingResult['defenderScore'] = 0;
+        } else {
+            console.log('Error: invalid argument for player position, must be "c" or "d"');
+            breakFlag = true;
+        }
+
+        if (breakFlag === false) {
+            pendingResult['challengeDBId'] = pendingResult['id'];
+            pendingResult['id'] = null;
+            console.log('submitting following forfeiture result:', pendingResult);
+        }
+    }
+
     public joinLadder(game) {
         this._router.navigate(['/join', {game: game}]);
     }

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -176,23 +176,26 @@ export class DashboardComponent {
     }
 
     public forfeitChallenge(challenge: object, playerPos: string) {
-        const pendingResult = challenge;
-        let breakFlag = false;
-        if (playerPos === 'c') {
-            pendingResult['challengerScore'] = 0;
-            pendingResult['defenderScore'] = 5;
-        } else if (playerPos === 'd') {
-            pendingResult['challengerScore'] = 5;
-            pendingResult['defenderScore'] = 0;
-        } else {
-            console.log('Error: invalid argument for player position, must be "c" or "d"');
-            breakFlag = true;
-        }
+        if (confirm('Do you reallt want to forfeit this challenge?')) {
+            const pendingResult = challenge;
+            let breakFlag = false;
+            if (playerPos === 'c') {
+                pendingResult['challengerScore'] = 0;
+                pendingResult['defenderScore'] = 5;
+            } else if (playerPos === 'd') {
+                pendingResult['challengerScore'] = 5;
+                pendingResult['defenderScore'] = 0;
+            } else {
+                console.log('Error: invalid argument for player position, must be "c" or "d"');
+                breakFlag = true;
+            }
 
-        if (breakFlag === false) {
-            pendingResult['challengeDBId'] = pendingResult['id'];
-            pendingResult['id'] = null;
-            console.log('submitting following forfeiture result:', pendingResult);
+            if (breakFlag === false) {
+                pendingResult['challengeDBId'] = pendingResult['id'];
+                pendingResult['id'] = null;
+                console.log('submitting following forfeiture result:', pendingResult);
+                this._pending.addResult(pendingResult);
+            }
         }
     }
 

--- a/src/app/sub-pages/join/join.component.html
+++ b/src/app/sub-pages/join/join.component.html
@@ -19,7 +19,7 @@
             <label for="">Would you like to link your Google account to this ladder entry? (Recommended): </label>
             <input class="join-checkbox" type="checkbox" [(ngModel)]="joinGoogle"><br>
         </div>
-        <input type="submit" [disabled]="selectedGame===undefined" (click)="addPending(selectedGame)" class="btn join-submit-button">    
+        <input type="submit" [disabled]="selectedGame===undefined || !joinName || !joinPsnId" (click)="addPending(selectedGame)" class="btn join-submit-button">    
     </div>
     
     <h4 *ngIf="userSubmitted === true">User has been submitted. Now currently pending approval by an admin. Thanks again for your interest!</h4>

--- a/src/app/sub-pages/match-history/match-history.component.css
+++ b/src/app/sub-pages/match-history/match-history.component.css
@@ -19,6 +19,14 @@
     width: 20%;
 }
 
+.match-history-text-winner {
+    color: #0d0;
+}
+
+.match-history-text-loser {
+    color: #d00;
+}
+
 .match-history-date {
     background-color: #a63446;
     color: #fff;

--- a/src/app/sub-pages/match-history/match-history.component.html
+++ b/src/app/sub-pages/match-history/match-history.component.html
@@ -8,9 +8,11 @@
                   <div class="match-history-game flex-container justify-center align-center font-bangers">{{ match.game }}</div>
                   <div class="match-history-date font-bangers text-center">{{ match.dateCompleted | date: 'fullDate' }}</div>
                   <button type="button" class="list-group-item match-history-button-align">
-                      <span class="label label-default space-cadet-bg">Rank {{ match.challengerRank }}</span><strong> {{ match.challengerName }}</strong>
+                      <span class="label label-default space-cadet-bg">Rank {{ match.challengerRank }}</span>
+                      <span [ngClass]="{'match-history-text-winner': match.challengerScore > match.defenderScore, 'match-history-text-loser': match.challengerScore < match.defenderScore}"><strong> {{ match.challengerName }}</strong></span>
                       <span class="font-bangers match-history-score">{{ match.challengerScore }} : {{ match.defenderScore }}</span>
-                      <strong> {{ match.defenderName }}</strong> <span class="label label-default space-cadet-bg">Rank {{ match.defenderRank }}</span>
+                      <span [ngClass]="{'match-history-text-winner': match.challengerScore < match.defenderScore, 'match-history-text-loser': match.challengerScore > match.defenderScore}"><strong> {{ match.defenderName }}</strong></span> 
+                      <span class="label label-default space-cadet-bg">Rank {{ match.defenderRank }}</span>
                     </button></div>
               
             </div>

--- a/src/app/sub-pages/place-challenge/place-challenge.component.ts
+++ b/src/app/sub-pages/place-challenge/place-challenge.component.ts
@@ -119,8 +119,11 @@ export class PlaceChallengeComponent {
 
         // make sure rank difference is greater than 0 (i.e. theyre not challenging someone below them)
         // also make sure that the rank difference is less than 4 (i.e. theyre not challenging someone too high for them)
+        // make an exception for sf5 - can challenge 5 ahead (fornow) in that game
         const rankDiff = challenger.rank - defender.rank;
-        if (rankDiff < 1 || rankDiff > 3) {result = false; }
+        if (this.selectedGame === 'sfv') {
+            if (rankDiff < 1 || rankDiff > 5) { result = false; }
+        } else if (rankDiff < 1 || rankDiff > 3) {result = false; }
 
         // see if the defender has a recent opponent id. if so, make sure its not matching the challnger
         if (defender.recentId) {

--- a/src/app/sub-pages/place-challenge/place-challenge.component.ts
+++ b/src/app/sub-pages/place-challenge/place-challenge.component.ts
@@ -24,6 +24,7 @@ export class PlaceChallengeComponent {
     private _user; // user login info
     private _listofPendingChallenges; // for anon: the list of pending challenges to avoid dupes
     private _listOfDBChallenges; // list of challenges in the database
+    private _CHALLENGETIME = 604800000; // how long a challenge has before the deadline passes in milliseconds
 
     // progression flags
     public canSelectGame = true;
@@ -209,8 +210,8 @@ export class PlaceChallengeComponent {
 
             if (this.challengeMethod === 1) {
                 // push to challenge db
-                const deadlineDate = Date.now() + 864000000; // new date + no. seconds in 10 days
-                challengeToBeApproved.deadline = deadlineDate; // assign deadline to 10 days from now
+                const deadlineDate = Date.now() + this._CHALLENGETIME; // new date + challenge deadline time
+                challengeToBeApproved.deadline = deadlineDate; // assign deadline to however long the current deadline window is
                 this._challengeDB.addChallenge(challengeToBeApproved);
                 console.log('submitting:', challengeToBeApproved, 'attacker:', this.selectedChallenger, 'defender', this.selectedDefender);
                 console.log('Challenge added to challenge DB');

--- a/src/app/sub-pages/submitted/submitted.component.html
+++ b/src/app/sub-pages/submitted/submitted.component.html
@@ -5,5 +5,5 @@
     <h4 *ngIf="currentParam === 'challenge-anon'">You challenge has been submitted. Since you did not link your Google account, we don't know if it's actually you who submitted it, so an admin will have to approve it. You should be contacted by an admin in discord relatively soon.</h4>
     <h4 *ngIf="currentParam === 'score-post'">Thank you for submitting your score. It is now awaiting admin approval. You should be contacted by an admin in discord to verify the score.</h4>
     <p>You should be routed to the home page automatically in 5 seconds. Please click the button to go there in case you don't want to wait.</p>
-    <button class="btn btn-info" routerLink="/home">Home</button>
+    <button class="btn btn-info" (click)="goHome()">Home</button>
 </div>

--- a/src/app/sub-pages/submitted/submitted.component.ts
+++ b/src/app/sub-pages/submitted/submitted.component.ts
@@ -10,6 +10,7 @@ import { Router, ActivatedRoute, Params } from '@angular/router';
 export class SubmitComponent implements OnInit {
 
     public currentParam;
+    private _timeOut;
 
     constructor (private _router: Router, private _actRoute: ActivatedRoute) {}
 
@@ -20,8 +21,19 @@ export class SubmitComponent implements OnInit {
             }
         });
 
-        setTimeout(() => {
+        this._timeOut = setTimeout(() => {
             this._router.navigate(['home'], {});
         }, 5000);
+
+        // cancel timeout if they navigate somewhere else prior to being routed home
+        this._router.events.subscribe(routeChange => {
+            clearTimeout(this._timeOut);
+        });
+    }
+
+    // cancel timeout if they click the button themselves
+    public goHome() {
+        clearTimeout(this._timeOut);
+        this._router.navigate(['home']);
     }
 }


### PR DESCRIPTION
Minor features and bugfixes. Also challenge window is now reduced from 10 days to 7 days.

Feature: A player's streak is correctly updated after a posted result is approved.
Feature: Names on match history page are now color coded according to whether they won or lost
Feature: Players now have the option of forfeiting a challenge. This automatically sumbits a 5-0 score for approval.
Feature: Challenges on the dashboard will now indicate if they have a score pending approval. Score posting and forfeit buttons are disabled if this is the case.

Bugfix: PSN/CFN ids and names are now required fields when submitting to the database.
Bugfix: Cleared the navigation timeout on the submission screen if the user navigates somewhere else during the timer. Previously if you clicked on another link, say the dashboard, the router would still take you to the home component after the 5 second timeout was complete.

Cleanup: Cleaned up some code and linter errors in news service