### PR TITLE
Backend and bugs

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5,12 +5,31 @@ const admin = require('firebase-admin');
 admin.initializeApp(functions.config().firebase);
 
 // player check firebase call?
-exports.playerCheck = functions.https.onRequest((req, res) => {
-    // const player2BeChecked = req.body.player;
-    // const game = req.body.game;
-    const playerList = functions.database.ref('/ladder/' + 'tekken' + '/players/');
-    console.log(playerList);
-    res.send('testing', playerList);
+exports.getChallenges = functions.https.onRequest((req, res) => {
+    
+    const query = admin.database().ref('/x-challenges');
+    const challenges = [];
+    let test = '';
+    query.once('value').then(snapshot => {
+        snapshot.forEach(childSnap => {
+            console.log('Child Snap:', childSnap.val());
+            challenges.push({
+                key: childSnap.key,
+                challenger: childSnap.val().challengerName,
+                defender: childSnap.val().defenderName,
+                deadline: new Date(childSnap.val().deadline)
+            });
+        })
+        res.send(challenges);
+    });
+
+    
+    
+    // const challengeRef = db.ref('/x-challenges');
+    // challengeRef.once('value', function(snapshot) {
+    //     res.send(snapshot.val().json());
+    // })
+    // // res.send('This is where i will have a list of challenges');
 
     
 })

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -32,25 +32,27 @@ export class ChallengeDatabaseService {
             const playerSub = this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
                 playerList.forEach(player => {
                     if (player.id === challenge.challengerId) {
-                        console.log('Match found - Challenger');
+                        // console.log('Match found - Challenger');
                         if (player.rank === challenge.challengerRank) {
-                            console.log('Ranks match');
+                            // console.log('Ranks match');
                         } else {
-                            console.log('Ranks do NOT match');
-                            console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
+                            // console.log('Ranks do NOT match');
+                            // console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
                             challenge.challengerRank = player.rank;
-                            console.log('Send the following object with updates to the challenge:', challenge);
+                            this.updateChallenge(challenge.id, challenge);
+                            // console.log('Send the following object with updates to the challenge:', challenge);
                         }
                     }
                     if (player.id === challenge.defenderId) {
-                        console.log('Match found - Defender');
+                        // console.log('Match found - Defender');
                         if (player.rank === challenge.defenderRank) {
-                            console.log('Ranks match');
+                            // console.log('Ranks match');
                         } else {
-                            console.log('Ranks do NOT match');
-                            console.log(`${challenge.defenderName}'s rank is ${challenge.defenderRank} but is ${player.rank} on the ladder.`);
+                            // console.log('Ranks do NOT match');
+                            // console.log(`${challenge.defenderName}'s rank is ${challenge.defenderRank} but is ${player.rank} on the ladder.`);
                             challenge.defenderRank = player.rank;
-                            console.log('Send the following object with updates to the challenge:', challenge);
+                            this.updateChallenge(challenge.id, challenge);
+                            // console.log('Send the following object with updates to the challenge:', challenge);
                         }
                     }
                 });
@@ -59,7 +61,7 @@ export class ChallengeDatabaseService {
         });
     }
 
-    public updateChallenger(id, challenge) {
+    public updateChallenge(id, challenge) {
         const challengeRef = this._database.list('/x-challenges');
         challengeRef.update(id, challenge);
     }

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -59,6 +59,11 @@ export class ChallengeDatabaseService {
         });
     }
 
+    public updateChallenger(id, challenge) {
+        const challengeRef = this._database.list('/x-challenges');
+        challengeRef.update(id, challenge);
+    }
+
     public deleteChallenge(id) {
         this._database.list('/x-challenges').remove(id);
     }

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { AngularFireDatabase } from 'angularfire2/database';
+import { LadderDatabaseService } from './../database/ladder-database.service';
 
 import NewsItem from './../../interfaces/news-item';
 import { AngularFireList, AngularFireObject, FirebaseOperation } from 'angularfire2/database/interfaces';
@@ -12,10 +13,43 @@ import ChallengeDB from './../../interfaces/challenge-db';
 
 export class ChallengeDatabaseService {
 
-    constructor (private _database: AngularFireDatabase) {}
+    private _challengeList;
+    private _currentPlayerList;
+
+    constructor (private _database: AngularFireDatabase, private _ladderDB: LadderDatabaseService) {
+        this.getListOfChallenges().subscribe(list => {
+            this._challengeList = list;
+        });
+    }
 
     public addChallenge(challenge: ChallengeDB) {
         this._database.list('/x-challenges').push(challenge);
+    }
+
+    public matchChallengeRank() {
+        this._challengeList.forEach(challenge => {
+            const foundChallenge = [];
+            this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
+                playerList.forEach(player => {
+                    if (player.id === challenge.challengerId) {
+                        console.log('Match found - Challenger');
+                        if (player.rank === challenge.challengerRank) {
+                            console.log('Ranks match');
+                        } else {
+                            console.log('Ranks do NOT match');
+                        }
+                    }
+                    if (player.id === challenge.defenderId) {
+                        console.log('Match found - Defender');
+                        if (player.rank === challenge.challengerRank) {
+                            console.log('Ranks match');
+                        } else {
+                            console.log('Ranks do NOT match');
+                        }
+                    }
+                });
+            });
+        });
     }
 
     public deleteChallenge(id) {

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -32,6 +32,7 @@ export class ChallengeDatabaseService {
     // those are the ranks eneter in. but lets say someone below them jumped them both and now they are #5 and #6
     // the challenge ranks are not updated and when the score goes to post, bad things happen. this resolves that problem
     public matchChallengeRank() {
+        console.log('Updating ranks in Challenge DB...');
         // iterate through each challenge
         this._challengeList.forEach(challenge => {
             // grab a list of players and subscribe to it. assign it to a var so we can unsub later

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -26,16 +26,26 @@ export class ChallengeDatabaseService {
         this._database.list('/x-challenges').push(challenge);
     }
 
+    // method used when updating the ranks on the challenge list to match the ranks on the ladder
+    // not using this will cause a problem when players move around due to other challenges but their rank
+    // on the challenge stays the same. for example if #5 challenged #4 then at the point of the challenge
+    // those are the ranks eneter in. but lets say someone below them jumped them both and now they are #5 and #6
+    // the challenge ranks are not updated and when the score goes to post, bad things happen. this resolves that problem
     public matchChallengeRank() {
+        // iterate through each challenge
         this._challengeList.forEach(challenge => {
-            const foundChallenge = [];
+            // grab a list of players and subscribe to it. assign it to a var so we can unsub later
             const playerSub = this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
+                // iterate through each player on the list looking for a matching id
                 playerList.forEach(player => {
+                    // if the iterated player id matches the challenger id then we have a match, so we need to make sure the ranks are good
                     if (player.id === challenge.challengerId) {
                         // console.log('Match found - Challenger');
                         if (player.rank === challenge.challengerRank) {
+                            // if the players rank on the ladder and rank on the challenge match up, then we good...
                             // console.log('Ranks match');
                         } else {
+                            // but if they DONT, edit the appropriate rank and update the challenge
                             // console.log('Ranks do NOT match');
                             // console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
                             challenge.challengerRank = player.rank;
@@ -44,6 +54,7 @@ export class ChallengeDatabaseService {
                         }
                     }
                     if (player.id === challenge.defenderId) {
+                        // same thing for the defender id
                         // console.log('Match found - Defender');
                         if (player.rank === challenge.defenderRank) {
                             // console.log('Ranks match');
@@ -56,6 +67,7 @@ export class ChallengeDatabaseService {
                         }
                     }
                 });
+                // unsub when we're done because we dont want this running everytime theres a database edit
                 playerSub.unsubscribe();
             });
         });

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -29,7 +29,7 @@ export class ChallengeDatabaseService {
     public matchChallengeRank() {
         this._challengeList.forEach(challenge => {
             const foundChallenge = [];
-            this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
+            const playerSub = this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
                 playerList.forEach(player => {
                     if (player.id === challenge.challengerId) {
                         console.log('Match found - Challenger');
@@ -37,17 +37,24 @@ export class ChallengeDatabaseService {
                             console.log('Ranks match');
                         } else {
                             console.log('Ranks do NOT match');
+                            console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
+                            challenge.challengerRank = player.rank;
+                            console.log('Send the following object with updates to the challenge:', challenge);
                         }
                     }
                     if (player.id === challenge.defenderId) {
                         console.log('Match found - Defender');
-                        if (player.rank === challenge.challengerRank) {
+                        if (player.rank === challenge.defenderRank) {
                             console.log('Ranks match');
                         } else {
                             console.log('Ranks do NOT match');
+                            console.log(`${challenge.defenderName}'s rank is ${challenge.defenderRank} but is ${player.rank} on the ladder.`);
+                            challenge.defenderRank = player.rank;
+                            console.log('Send the following object with updates to the challenge:', challenge);
                         }
                     }
                 });
+                playerSub.unsubscribe();
             });
         });
     }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.css
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.css
@@ -33,6 +33,15 @@
     background-color: #eeeeff;
 }
 
+.challenge-pending-force-rank-row {
+    align-items: center;
+    margin-top: 10px;
+}
+
+.challenge-pending-force-rank-row button {
+    margin-left: 30px;
+}
+
 .challenge-pending-result-side-row {
     min-height: 86px;
     display: flex;

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -1,6 +1,5 @@
 <div class="font-titi">
     <h1 class="font-bangers text-center">Challenge Management</h1>
-    <button class="btn-default" (click)="matchTest()">Test</button>
     <h3 class="font-bangers text-center">Pending Approval</h3>
     <div class="container-fluid">
         <div class="row" *ngIf="listOfPendingChallenges?.length === 0">
@@ -56,6 +55,10 @@
                 <button class="btn btn-danger" (click)="deleteActiveChallenge(challenge.id)">Delete</button>
             </div>
         </div> <!-- end looped active challenge row -->
+        <div class="flex-container justify-center challenge-pending-force-rank-row">
+            <p>To force a rank update on challenges, click this button.</p>
+            <button class="btn btn-defualt" (click)="matchRank()">Update Ranks</button>
+        </div>
         <div class="row" *ngIf="editScore === true"> <!-- begin score edit div -->
             <div class="col-sm-3 col-sm-offset-3">
                 <label>Challenger Score: </label>

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.html
@@ -1,5 +1,6 @@
 <div class="font-titi">
     <h1 class="font-bangers text-center">Challenge Management</h1>
+    <button class="btn-default" (click)="matchTest()">Test</button>
     <h3 class="font-bangers text-center">Pending Approval</h3>
     <div class="container-fluid">
         <div class="row" *ngIf="listOfPendingChallenges?.length === 0">

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -290,4 +290,8 @@ export class ChallengeManagementComponent implements OnInit {
         return resultStreak;
     }
 
+    public matchTest() {
+        this._challengeDB.matchChallengeRank();
+    }
+
 }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -290,6 +290,8 @@ export class ChallengeManagementComponent implements OnInit {
         return resultStreak;
     }
 
+    // method to force a rank update on challenges
+    // use this if the ranks on the challenge do not match the ranks on the ladder due to player movement
     public matchRank() {
         this._challengeDB.matchChallengeRank();
     }

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -290,7 +290,7 @@ export class ChallengeManagementComponent implements OnInit {
         return resultStreak;
     }
 
-    public matchTest() {
+    public matchRank() {
         this._challengeDB.matchChallengeRank();
     }
 

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -200,6 +200,8 @@ export class ChallengeManagementComponent implements OnInit {
         this._matchDB.addMatch(result);
         this._challengeDB.deleteChallenge(result.challengeDBId);
         this._pending.deleteResult(result.id);
+        // run a check on the challenge database to adjust the ranks of any players who might have moved
+        this._challengeDB.matchChallengeRank();
         this._postButtonClicked = false;
 }
 
@@ -237,6 +239,8 @@ export class ChallengeManagementComponent implements OnInit {
         // remove result and challenge from database
         this._challengeDB.deleteChallenge(result.challengeDBId);
         this._pending.deleteResult(result.id);
+        // run a check on the challenge database to adjust the ranks of any players who might have moved
+        this._challengeDB.matchChallengeRank();
         this._postButtonClicked = false;
     }
 

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -22,6 +22,7 @@ export class ChallengeManagementComponent implements OnInit {
     public editScore = false; // is the user editing score?
     public selectedChallenge;
     private _CHALLENGETIME = 604800000; // how long a challenge has to be completed after approval, in milliseconds
+    private _MAXCHALLENGERANK = 5; // the number of spots a player can challenge above.
 
     // ngmodel fields
     public challengerScoreInput: string;
@@ -114,14 +115,29 @@ export class ChallengeManagementComponent implements OnInit {
 
                 // make sure we're coming from the challenge management page with this flag check
                 if (this._postButtonClicked === true) {
-                    // sort list by rank lol
 
+                    // find the appropriate player and assign him as the defender
                     this._currentDefender = playerList.find(function(e, i, a) {
                         if (e.id === result.defenderId) { return true; }
                     });
-                    for (let rank = result.defenderRank - 1; rank < result.challengerRank; rank++ ) {
-                        this.listOfAffectedPlayers.push(playerList[rank]);
+                    // check to see if the defenders rank is more than the allowed 5 spot move up. this can happen if
+                    // someone was challenged, but before completing the defending challenged, completed their own attacking
+                    // challenge and moved up. if the rank difference is fine, stick to the current method of grabbing players
+                    if (result.challengerRank - result.defenderRank <= this._MAXCHALLENGERANK) {
+                        // grab all players affected by the challenge. note that because we are getting players from a sorted array,
+                        // it starts at index 0, not 1. this is why we go from defender rank - 1 to challenger rank - 1:
+                        // in the array, first place is index 0, not index 1
+                        for (let rank = result.defenderRank - 1; rank < result.challengerRank; rank++ ) {
+                            this.listOfAffectedPlayers.push(playerList[rank]);
+                        }
+                    } else {
+                        // if its not, then grab the 5 affected players above the challenger including the challenger
+                        // note that we start at max challenge - 1 to account for the array starting at 0
+                        for (let rank = result.challengerRank - this._MAXCHALLENGERANK - 1; rank < result.challengerRank; rank++ ) {
+                            this.listOfAffectedPlayers.push(playerList[rank]);
+                        }
                     }
+
                     console.log('affected players:', this.listOfAffectedPlayers);
                     console.log('current defender', this._currentDefender);
                     const lastIndex = this.listOfAffectedPlayers.length - 1;


### PR DESCRIPTION
Feature: Began writing backend code for Google's Cloud Functions. There's now an API call available to grab a list of challenges in JSON form. Ideally, this would be in preparation of implementing a discord bot that could parse that list and post to the channel, but I'm a ways off from learning how to do that, lol.

Semi Feature: You can now force a rank update on the challenge management section of the admin page. This goes through each challenge and makes sure that their rank matches what they are currently at on the ladder. This should now automatically be called whenever someone posts a result, but in the event it doesn't, the button is there. It's also useful if you manually edited rank in the player management and need to update the challenges as well.

Bugfix: Previously if someone had moved out of the challenge range of a defender who had already placed a challenge, that defender would still be jumped in the event of a loss. For example, Matt is rank 10, challenges Joe who is rank 5. Joes beats someone ahead of him and now moves to rank 3. If Matt beat Joes, he should only go up to rank 5, because the maximum is 5 slots. That now actually happens.

Bugfix: As previously mentioned, challenges should now update their respective player ranks so complications due to player movement prior to a completed challenges should now be resolved.