### PR TITLE
More bugfixes

### DIFF
--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -16,7 +16,7 @@ import { DashboardComponent } from './sub-pages/dashboard/dashboard.component';
 import { PlaceChallengeComponent } from './sub-pages/place-challenge/place-challenge.component';
 import { SubmitComponent } from './sub-pages/submitted/submitted.component';
 
-import { RouterGuard } from './services/router-guard.service';
+import { LoggedInRouterGuard } from './services/logged-in-router-guard.service';
 
 
 const routes: Routes = [{
@@ -57,7 +57,8 @@ const routes: Routes = [{
   },
   {
     path: 'dashboard',
-    component: DashboardComponent
+    component: DashboardComponent,
+    canActivate: [ LoggedInRouterGuard ]
   },
   {
     path: 'place-challenge',
@@ -81,7 +82,7 @@ const routes: Routes = [{
 @NgModule({
     imports: [ RouterModule.forRoot(routes)],
     exports: [ RouterModule ],
-    providers: [ RouterGuard ]
+    providers: [ LoggedInRouterGuard ]
   })
 
 export class MainRoutingModule {}

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -18,9 +18,6 @@ export class ChallengeDatabaseService {
     private _inServiceSub;
 
     constructor (private _database: AngularFireDatabase, private _ladderDB: LadderDatabaseService) {
-        this._inServiceSub = this.getListOfChallenges().subscribe(list => {
-            this._challengeList = list;
-        });
     }
 
     public addChallenge(challenge: ChallengeDB) {
@@ -35,60 +32,59 @@ export class ChallengeDatabaseService {
     // those are the ranks eneter in. but lets say someone below them jumped them both and now they are #5 and #6
     // the challenge ranks are not updated and when the score goes to post, bad things happen. this resolves that problem
     public matchChallengeRank(flag: boolean) {
-        // bonly run this when its called
+        // only run this when its called
+        // NOTE: this is kind of a failsafe in case  unsubscribe doesnt work as planned, but can probablly be removed later
         if (flag !== true) { return; }
         console.log('Updating ranks in Challenge DB...');
-        // resub if necessary
-        if (this._inServiceSub.closed === true) {
-            // console.log('sub open');
-            this._inServiceSub = this.getListOfChallenges().subscribe(list => {
-                this._challengeList = list;
-            });
-            
-        }
-        // iterate through each challenge
-        this._challengeList.forEach(challenge => {
-            // grab a list of players and subscribe to it. assign it to a var so we can unsub later
-            const playerSub = this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
-                // iterate through each player on the list looking for a matching id
-                playerList.forEach(player => {
-                    // if the iterated player id matches the challenger id then we have a match, so we need to make sure the ranks are good
-                    if (player.id === challenge.challengerId) {
-                        // console.log('Match found - Challenger');
-                        if (player.rank === challenge.challengerRank) {
-                            // if the players rank on the ladder and rank on the challenge match up, then we good...
-                            // console.log('Ranks match');
-                        } else {
-                            // but if they DONT, edit the appropriate rank and update the challenge
-                            // console.log('Ranks do NOT match');
-                            // console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
-                            challenge.challengerRank = player.rank;
-                            this.updateChallenge(challenge.id, challenge);
-                            // console.log('Send the following object with updates to the challenge:', challenge);
+
+        // console.log('sub open');
+        this._inServiceSub = this.getListOfChallenges().subscribe(list => {
+            this._challengeList = list;
+
+            // iterate through each challenge
+            this._challengeList.forEach(challenge => {
+                // grab a list of players and subscribe to it. assign it to a var so we can unsub later
+                const playerSub = this._ladderDB.getPlayers(challenge.game).subscribe(playerList => {
+                    // iterate through each player on the list looking for a matching id
+                    playerList.forEach(player => {
+                        // if the iterated player id matches the challenger id then we have a match, so we need to make sure the ranks are good
+                        if (player.id === challenge.challengerId) {
+                            // console.log('Match found - Challenger');
+                            if (player.rank === challenge.challengerRank) {
+                                // if the players rank on the ladder and rank on the challenge match up, then we good...
+                                // console.log('Ranks match');
+                            } else {
+                                // but if they DONT, edit the appropriate rank and update the challenge
+                                // console.log('Ranks do NOT match');
+                                // console.log(`${challenge.challengerName}'s rank is ${challenge.challengerRank} but is ${player.rank} on the ladder.`);
+                                challenge.challengerRank = player.rank;
+                                this.updateChallenge(challenge.id, challenge);
+                                // console.log('Send the following object with updates to the challenge:', challenge);
+                            }
                         }
-                    }
-                    if (player.id === challenge.defenderId) {
-                        // same thing for the defender id
-                        // console.log('Match found - Defender');
-                        if (player.rank === challenge.defenderRank) {
-                            // console.log('Ranks match');
-                        } else {
-                            // console.log('Ranks do NOT match');
-                            // console.log(`${challenge.defenderName}'s rank is ${challenge.defenderRank} but is ${player.rank} on the ladder.`);
-                            challenge.defenderRank = player.rank;
-                            this.updateChallenge(challenge.id, challenge);
-                            // console.log('Send the following object with updates to the challenge:', challenge);
+                        if (player.id === challenge.defenderId) {
+                            // same thing for the defender id
+                            // console.log('Match found - Defender');
+                            if (player.rank === challenge.defenderRank) {
+                                // console.log('Ranks match');
+                            } else {
+                                // console.log('Ranks do NOT match');
+                                // console.log(`${challenge.defenderName}'s rank is ${challenge.defenderRank} but is ${player.rank} on the ladder.`);
+                                challenge.defenderRank = player.rank;
+                                this.updateChallenge(challenge.id, challenge);
+                                // console.log('Send the following object with updates to the challenge:', challenge);
+                            }
                         }
+                    });
+                    // unsub when we're done because we dont want this running everytime theres a database edit
+                    playerSub.unsubscribe();
+                    this._inServiceSub.unsubscribe();
+                    // console.log('this is how an unssub looks:', this._inServiceSub);
+                    if (this._inServiceSub.closed === true) {
+                        // console.log('sub closed!');
+                        flag = false;
                     }
                 });
-                // unsub when we're done because we dont want this running everytime theres a database edit
-                playerSub.unsubscribe();
-                this._inServiceSub.unsubscribe();
-                // console.log('this is how an unssub looks:', this._inServiceSub);
-                if (this._inServiceSub.closed === true) {
-                    // console.log('sub closed!');
-                    flag = false;
-                }
             });
         });
     }
@@ -104,7 +100,7 @@ export class ChallengeDatabaseService {
         this._database.list('/x-challenges').remove(id).catch(error => alert(error)).then(
             () => {
                 console.log('Challenge Deleted.');
-                // this.matchChallengeRank(true);
+                this.matchChallengeRank(true);
             }
         );
     }

--- a/src/app/services/database/challenge-database.service.ts
+++ b/src/app/services/database/challenge-database.service.ts
@@ -34,7 +34,9 @@ export class ChallengeDatabaseService {
     // on the challenge stays the same. for example if #5 challenged #4 then at the point of the challenge
     // those are the ranks eneter in. but lets say someone below them jumped them both and now they are #5 and #6
     // the challenge ranks are not updated and when the score goes to post, bad things happen. this resolves that problem
-    public matchChallengeRank() {
+    public matchChallengeRank(flag: boolean) {
+        // bonly run this when its called
+        if (flag !== true) { return; }
         console.log('Updating ranks in Challenge DB...');
         // resub if necessary
         if (this._inServiceSub.closed === true) {
@@ -85,6 +87,7 @@ export class ChallengeDatabaseService {
                 // console.log('this is how an unssub looks:', this._inServiceSub);
                 if (this._inServiceSub.closed === true) {
                     // console.log('sub closed!');
+                    flag = false;
                 }
             });
         });
@@ -101,6 +104,7 @@ export class ChallengeDatabaseService {
         this._database.list('/x-challenges').remove(id).catch(error => alert(error)).then(
             () => {
                 console.log('Challenge Deleted.');
+                // this.matchChallengeRank(true);
             }
         );
     }

--- a/src/app/services/logged-in-router-guard.service.ts
+++ b/src/app/services/logged-in-router-guard.service.ts
@@ -6,21 +6,23 @@ import { LoginService } from './login.service';
 
 export class LoggedInRouterGuard implements CanActivate {
 
-    private _adminUidList = ['mkomTbU76VUR5tIoLmmyP1luR5q1', 'Gxr9qQ1pczOCLyncfhLiLdhvhy32',
-    'xFDVJ8Dq9CZR8PmiixbSNX5FpNv2', 'VtvMxuaYxGQp1eROh63SkO1S13k1'];
-
-
     constructor (private login: LoginService, private route: Router) {}
 
     // this router guard prevents people from visiting a page if they're not logged in
     canActivate() {
-        if (this.login.afAuth.auth.currentUser === null) { // check to see if a user is logged in at all
-            this.route.navigate(['home']); // if not, get them out
-            console.log('returned false...');
+        // map the observable from the login service...
+        return this.login.getLoggedInUserObs().map(user => {
+            // if the user exists, we good...
+            if (user) {
+                return true;
+            }
+
+            // since if the user was good we already returned, this means any code here only executes if there's no user
+            // thus, send em packing...
+            this.route.navigate(['home']);
             return false;
-        } else { // if so, yay
-            console.log('returned true...');
-            return true;
-        }
+
+        });
+
     }
 }

--- a/src/app/services/logged-in-router-guard.service.ts
+++ b/src/app/services/logged-in-router-guard.service.ts
@@ -16,9 +16,10 @@ export class LoggedInRouterGuard implements CanActivate {
     canActivate() {
         if (this.login.afAuth.auth.currentUser === null) { // check to see if a user is logged in at all
             this.route.navigate(['home']); // if not, get them out
+            console.log('returned false...');
             return false;
-        } else { // if not, get them out too
-            this.route.navigate(['home']);
+        } else { // if so, yay
+            console.log('returned true...');
             return true;
         }
     }

--- a/src/app/services/logged-in-router-guard.service.ts
+++ b/src/app/services/logged-in-router-guard.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { LoginService } from './login.service';
+
+@Injectable()
+
+export class LoggedInRouterGuard implements CanActivate {
+
+    private _adminUidList = ['mkomTbU76VUR5tIoLmmyP1luR5q1', 'Gxr9qQ1pczOCLyncfhLiLdhvhy32',
+    'xFDVJ8Dq9CZR8PmiixbSNX5FpNv2', 'VtvMxuaYxGQp1eROh63SkO1S13k1'];
+
+
+    constructor (private login: LoginService, private route: Router) {}
+
+    // this router guard prevents people from visiting a page if they're not logged in
+    canActivate() {
+        if (this.login.afAuth.auth.currentUser === null) { // check to see if a user is logged in at all
+            this.route.navigate(['home']); // if not, get them out
+            return false;
+        } else { // if not, get them out too
+            this.route.navigate(['home']);
+            return true;
+        }
+    }
+}

--- a/src/app/services/login.service.ts
+++ b/src/app/services/login.service.ts
@@ -21,7 +21,7 @@ export class LoginService {
 
     public logout() {
         this.afAuth.auth.signOut();
-        if (this.route.url.includes('admin')) {
+        if (this.route.url.includes('admin') || (this.route.url.includes('dashboard'))) {
             this.route.navigateByUrl('home');
         }
     }

--- a/src/app/sub-pages/admin/admin.component.ts
+++ b/src/app/sub-pages/admin/admin.component.ts
@@ -15,7 +15,7 @@ export class AdminComponent implements OnInit {
 
     // method to toggle hideMenu to true or false on a click
     public toggleMenu() {
-        console.log('burger triggered');
+        // console.log('burger triggered');
         if (this.hideMenu === true) {
             this.hideMenu = false;
         } else {

--- a/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
+++ b/src/app/sub-pages/admin/challenge-management/challenge-management.component.ts
@@ -96,7 +96,7 @@ export class ChallengeManagementComponent implements OnInit, OnDestroy {
     // method to allow input of a score
     public addScore(challenge) {
         // run the challenge match here to ensure that the ranks are up to date
-        this._challengeDB.matchChallengeRank();
+        this._challengeDB.matchChallengeRank(true);
         this.editScore = true;
         this.selectedChallenge = challenge;
     }
@@ -355,7 +355,7 @@ export class ChallengeManagementComponent implements OnInit, OnDestroy {
     // method to force a rank update on challenges
     // use this if the ranks on the challenge do not match the ranks on the ladder due to player movement
     public matchRank() {
-        this._challengeDB.matchChallengeRank();
+        this._challengeDB.matchChallengeRank(true);
     }
 
 }

--- a/src/app/sub-pages/admin/player-management/player-management.component.css
+++ b/src/app/sub-pages/admin/player-management/player-management.component.css
@@ -42,7 +42,7 @@
     margin-top: 25px;
     z-index: 40 !important;
     position: absolute;
-    top: 5%;
+    top: 5vh;
     left: 32.5%;
     transform: translate(-270%, 0px);
     transition: 1s all;

--- a/src/app/sub-pages/admin/player-management/player-management.component.html
+++ b/src/app/sub-pages/admin/player-management/player-management.component.html
@@ -27,6 +27,8 @@
                     <p class="text-center">PSN Id: {{ selectedPlayer.psnId }}</p>
                     <p class="text-center">Wins: {{ selectedPlayer.wins }}</p>
                     <p class="text-center">Losses: {{ selectedPlayer.losses }}</p>
+                    <p class="text-center">Game Wins: {{ selectedPlayer.gameWins }}</p>
+                    <p class="text-center">Game Losses: {{ selectedPlayer.gameLosses }}</p>
                     <p class="text-center">Streak: {{ selectedPlayer.streak }}</p>
                     <div class="flex-container justify-around">
                         <button class="btn btn-success" (click)="allowUpdatePlayer()">Update Player</button>
@@ -66,6 +68,10 @@
                 <input type="number" name="updateLossesField" [(ngModel)]="updateLossesField" required><br>
                 <label>ELO:</label>
                 <input type="number" name="updateEloField" [(ngModel)]="updateEloField" required><br>
+                <label>Game Wins:</label>
+                <input type="number" name="updateGameWinsField" [(ngModel)]="updateGameWinsField" required><br>
+                <label>Game Losses:</label>
+                <input type="number" name="updateGameLossesField" [(ngModel)]="updateGameLossesField" required><br>
                 <label>Streak</label>
                 <input type="text" name="updateStreakField" [(ngModel)]="updateStreakField" required><br>
                 <input type="submit" class="btn btn-success" [disabled]="playerUpdateForm.invalid">

--- a/src/app/sub-pages/admin/player-management/player-management.component.ts
+++ b/src/app/sub-pages/admin/player-management/player-management.component.ts
@@ -45,6 +45,8 @@ export class PlayerManagementComponent implements OnInit, OnDestroy {
     public updateLossesField: number;
     public updateEloField: number;
     public updateStreakField: string;
+    public updateGameWinsField: number;
+    public updateGameLossesField: number;
 
     constructor(private _ladderDB: LadderDatabaseService) {
     }
@@ -135,6 +137,8 @@ export class PlayerManagementComponent implements OnInit, OnDestroy {
         this.updateStreakField = this.selectedPlayer.streak;
         this.updateEloField = this.selectedPlayer.elo;
         this.updateRankField = this.selectedPlayer.rank;
+        this.updateGameWinsField = this.selectedPlayer.gameWins;
+        this.updateGameLossesField = this.selectedPlayer.gameLosses;
     }
 
     // method to hide the edit player box. doesn't reset the fields since you can't see them and any reappearance of the fields
@@ -155,7 +159,9 @@ export class PlayerManagementComponent implements OnInit, OnDestroy {
             losses: value.updateLossesField,
             elo: value.updateEloField,
             streak: value.updateStreakField,
-            rank: value.updateRankField
+            rank: value.updateRankField,
+            gameWins: value.updateGameWinsField,
+            gameLosses: value.updateGameLossesField
         };
         this._ladderDB.updatePlayer(updatedInfo, id, this.currentGame.ref);
         // after the update call, hide the edit player field if its shown, then remove any selected player.

--- a/src/app/sub-pages/dashboard/dashboard.component.html
+++ b/src/app/sub-pages/dashboard/dashboard.component.html
@@ -32,6 +32,11 @@
             <!-- <p *ngIf="userStatus[game.ref].length > 0">Rank: {{ userStatus[game.ref][0].rank }} ELO: {{ userStatus[game.ref][0].rank }} Record: {{ userStatus[game.ref][0].wins }}-{{ userStatus[game.ref][0].losses}}
                 Name: {{ userStatus[game.ref][0].name }} Gamertag: {{ userStatus[game.ref][0].psnId }}</p> -->
         </div> <!-- end looped row -->
+        <div class="row">
+            <div class="col-sm-12">
+                <p>*If you have already signed up, but you aren't seeing anything here, use the link account button.</p>
+            </div>
+        </div>
     </div> <!-- end container -->
     <div class="container"> <!-- begin challenge status container -->
         <div class="row">

--- a/src/app/sub-pages/dashboard/dashboard.component.ts
+++ b/src/app/sub-pages/dashboard/dashboard.component.ts
@@ -38,43 +38,19 @@ export class DashboardComponent implements OnInit {
 
     // instantiate necessary lists...
     ngOnInit() {
-        // instantiate list of challenges then put them in teh correct array
-        this._challengeDB.getListOfChallenges().subscribe(challengeList => {
-            challengeList.forEach(challenge => {
-                if (challenge['challengerGoogle'] === this._user.uid) {
-                    // console.log('selected challenge', challenge);
-                    this.listOfChallenges.att.push(challenge);
-                }
-                if (challenge['defenderGoogle'] === this._user.uid) {
-                    // console.log('selected challenge', challenge);
-                    // challenge['isPending'] = this.isResultPending(challenge['id']);
-                    this.listOfChallenges.def.push(challenge);
-                }
-            });
-            console.log('challengeArrayBefore', this.listOfChallenges);
-            this.listOfChallenges.att.forEach(challenge => {
-                console.log(challenge.id, challenge, challenge.deadline, challenge.id);
-                challenge['isPending'] = this.isResultPending(challenge.challengerId, challenge.defenderId);
-            });
-            this.listOfChallenges.def.forEach(challenge => {
-                challenge['isPending'] = this.isResultPending(challenge.challengerId, challenge.defenderId);
-            });
-            console.log('challenge array yarrr', this.listOfChallenges);
-        });
-
-    }
-    constructor(public login: LoginService, private _ladderDB: LadderDatabaseService, private _pending: PendingDatabaseService,
-    private _challengeDB: ChallengeDatabaseService, private _router: Router) {
-
-        // ..login info
-        this.login.getLoggedInUserObs().map(user => {
-            const newUser = {
-                email: user.email,
-                displayName: user.displayName,
-                photoUrl: user.photoURL,
-                uid: user.uid
-            };
-            return newUser;
+         // ..login info
+         this.login.getLoggedInUserObs().map(user => {
+             if (user) {
+                const newUser = {
+                    email: user.email,
+                    displayName: user.displayName,
+                    photoUrl: user.photoURL,
+                    uid: user.uid
+                };
+                return newUser;
+             } else {
+                 return null;
+             }
         })
         .subscribe(user => {
             this._user = user;
@@ -106,7 +82,33 @@ export class DashboardComponent implements OnInit {
             }); // end gamelist iteration
         }); // end gamelist subscribe
 
-        
+        // instantiate list of challenges then put them in teh correct array
+        this._challengeDB.getListOfChallenges().subscribe(challengeList => {
+            challengeList.forEach(challenge => {
+                if (challenge['challengerGoogle'] === this._user.uid) {
+                    // console.log('selected challenge', challenge);
+                    this.listOfChallenges.att.push(challenge);
+                }
+                if (challenge['defenderGoogle'] === this._user.uid) {
+                    // console.log('selected challenge', challenge);
+                    // challenge['isPending'] = this.isResultPending(challenge['id']);
+                    this.listOfChallenges.def.push(challenge);
+                }
+            });
+            console.log('challengeArrayBefore', this.listOfChallenges);
+            this.listOfChallenges.att.forEach(challenge => {
+                console.log(challenge.id, challenge, challenge.deadline, challenge.id);
+                challenge['isPending'] = this.isResultPending(challenge.challengerId, challenge.defenderId);
+            });
+            this.listOfChallenges.def.forEach(challenge => {
+                challenge['isPending'] = this.isResultPending(challenge.challengerId, challenge.defenderId);
+            });
+            console.log('challenge array yarrr', this.listOfChallenges);
+        });
+
+    }
+    constructor(public login: LoginService, private _ladderDB: LadderDatabaseService, private _pending: PendingDatabaseService,
+    private _challengeDB: ChallengeDatabaseService, private _router: Router) { 
     } // end constructor
 
     // method to initiate linking a google account to a spot on the ladder. takes in the game ref from the appropriatte entry

--- a/src/app/sub-pages/join/join.component.ts
+++ b/src/app/sub-pages/join/join.component.ts
@@ -52,6 +52,12 @@ export class JoinComponent implements OnInit {
     // method for added pending request
     public addPending(game: string) {
 
+        // make sure that the player didn't click the box without logging, and if they did, warn them
+        if (this._login.afAuth.auth.currentUser === null && this.joinGoogle === true) {
+            alert('You are attempting to link a google account without logging in first. Please login.');
+            return;
+        }
+
         // create the object to be pushed
         const pendingToBeAdded = {
             name: this.joinName,


### PR DESCRIPTION
Feature: Player management should now allow editing of game wins and losses
Feature: Created a router guard for dashboard component. This will eventually apply to the join component as well. While navigation through the page to the dashboard was not possible, you could still type in the address and go to a dashboard with no login. That is no longer the case.
Feature: Logging out in the dashboard will now kick you to the home screen.
Feature: Attempting to join the ladder with a linked account without being logged in now alerts the player and reminds them to login. (Thanks Scott)

Bugfiix: Finally figured out the bug would cause the reappearing challenge, so the challenge rank updates now correctly run immediately after a score post. They also run when entering a score, which I decided to leave in to account for manual rank editing.
Bugfix: Fixed console errors that would happen if someone was either on the dashboard without a login or logged out while on the dashboard.